### PR TITLE
Issue with file extension in file subproblem

### DIFF
--- a/inginious/common/tasks_problems.py
+++ b/inginious/common/tasks_problems.py
@@ -236,7 +236,7 @@ class FileProblem(Problem):
             if problem_content["allowed_exts"] == "":
                 del problem_content["allowed_exts"]
             else:
-                problem_content["allowed_exts"] = problem_content["allowed_exts"].split(',')
+                problem_content["allowed_exts"] = [extension.strip() for extension in problem_content["allowed_exts"].split(',')]
 
         if "max_size" in problem_content:
             try:


### PR DESCRIPTION
The code isn’t removing extra spaces when splitting the file extensions. So if you input something like ".pdf, .png", it ends up with " .png" (with a space) instead of just ".png". Because of this, files with the ".png" extension won’t be recognized properly.