### PR TITLE
Fix user creation using bind_user, and add option to force username to match binding name

### DIFF
--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -486,11 +486,13 @@ class UserManager:
         user = self._database.users.find_one_and_update({"activate": activate_hash}, {"$unset": {"activate": True}})
         return user is not None
 
-    def bind_user(self, auth_id, user):
+    def bind_user(self, auth_id, user, force_username=False):
         """
         Add a binding method to a user
         :param auth_id: The binding method id
         :param user: User object
+        :param force_username: If True, a user created with this binding will have its username set immediately.
+                               If False (default), the created user will have an empty username, and later be asked to provide one.
         :return: Boolean if method has been add
         """
         username, realname, email, additional = user
@@ -532,7 +534,9 @@ class UserManager:
                 return False
             else:
                 # New user, create an account using email address
-                user_profile = {"username": "", "realname": realname, "email": email,
+                # If force_username is set, also use the given username
+                new_username = username if force_username else ""
+                user_profile = {"username": new_username, "realname": realname, "email": email,
                                 "bindings": {auth_id: [username, additional]}, "language": self.session_language(),
                                 "code_indentation": self.session_code_indentation(), "tos_accepted": False}
 

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -486,13 +486,11 @@ class UserManager:
         user = self._database.users.find_one_and_update({"activate": activate_hash}, {"$unset": {"activate": True}})
         return user is not None
 
-    def bind_user(self, auth_id, user, force_username=False):
+    def bind_user(self, auth_id, user):
         """
         Add a binding method to a user
         :param auth_id: The binding method id
         :param user: User object
-        :param force_username: If True, a user created with this binding will have its username set immediately.
-                               If False (default), the created user will have an empty username, and later be asked to provide one.
         :return: Boolean if method has been add
         """
         username, realname, email, additional = user
@@ -534,9 +532,7 @@ class UserManager:
                 return False
             else:
                 # New user, create an account using email address
-                # If force_username is set, also use the given username
-                new_username = username if force_username else ""
-                user_profile = {"username": new_username, "realname": realname, "email": email,
+                user_profile = {"username": "", "realname": realname, "email": email,
                                 "bindings": {auth_id: [username, additional]}, "language": self.session_language(),
                                 "code_indentation": self.session_code_indentation(), "tos_accepted": False}
 

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -536,12 +536,7 @@ class UserManager:
                                 "bindings": {auth_id: [username, additional]}, "language": self.session_language(),
                                 "code_indentation": self.session_code_indentation(), "tos_accepted": False}
 
-                self._database.users.insert_one({"username": user["username"],
-                                                 "realname": user["realname"],
-                                                 "email": user["email"],
-                                                 "bindings": user["bindings"],
-                                                 "language": user["language"],
-                                                 "code_indentation": user["code_indentation"]})
+                self._database.users.insert_one(user_profile)
                 self.connect_user(user_profile)
 
         return True


### PR DESCRIPTION
The current implementation of `bind_user` seemingly mixes between `user` being a tuple, and being indexable as a dictionary containing `["username"]`, `["realname"]` etc.

The [frontend/plugins/auth/ldap_auth.py](https://github.com/INGInious/INGInious/blob/main/inginious/frontend/plugins/auth/ldap_auth.py) file calls `bind_user` with a simple tuple, which causes exceptions when creating new users.

This PR tries to fix this by expecting `user` to be a tuple, which works in my particular case, but I am unable to see if any code was relying on the old behavior.
