### PR TITLE
force two values in return and handle redirect outside of function

### DIFF
--- a/inginious/frontend/pages/course_register.py
+++ b/inginious/frontend/pages/course_register.py
@@ -26,12 +26,14 @@ class CourseRegisterPage(INGIniousAuthPage):
         user_info = self.user_manager.get_user_info(username)
 
         if self.user_manager.course_is_user_registered(course, username) or not course.is_registration_possible(user_info):
-            return redirect(self.app.get_path("course", course.get_id()))
+            return course, None
 
         return course, username
 
     def GET_AUTH(self, courseid):
-        course, _ = self.basic_checks(courseid)
+        course, username = self.basic_checks(courseid)
+        if not username:
+            return redirect(self.app.get_path("course", course.get_id()))
         return self.template_helper.render("course_register.html", course=course, error=False)
 
     def POST_AUTH(self, courseid):


### PR DESCRIPTION
This pull request proposes a fix for issue #1018 .
basic_checks always return a tuple of two values.
redirect is handled in GET method.