### PR TITLE
Add JPLAG docker environment

### DIFF
--- a/inginious/frontend/plugins/jplag/container/Dockerfile
+++ b/inginious/frontend/plugins/jplag/container/Dockerfile
@@ -4,14 +4,8 @@
 # Create a .zip file containing one directory per student, each containing the student's submission. The .zip file should be named "submissions.zip".
 # Then, run the container with the following command :
 #
-#docker run -v "$(pwd)/test_submissions.zip":/jplag/input/submissions.zip -e JPLAG_LANGUAGE=python3 --entrypoint python3 jplag:latest
-# -c "
-# import sys
-# from unittest.mock import MagicMock
-# sys.modules['inginious_container_api'] = MagicMock()
-# sys.modules['inginious_container_api.feedback'] = MagicMock()
-# exec(open('/course/run.py').read())
-# "
+# docker run  -v "$(pwd)/test_submissions.zip":/jplag/input/submissions.zip -e JPLAG_LANGUAGE=python3
+# --entrypoint /bin/bash  jplag:latest  -c "python3 /course/run.py"
 #
 # The mock is necessary to avoid import errors, as the container expects to be run in an INGInious environment.
 

--- a/inginious/frontend/plugins/jplag/container/Dockerfile
+++ b/inginious/frontend/plugins/jplag/container/Dockerfile
@@ -1,0 +1,37 @@
+# DOCKER-VERSION 1.1.0
+
+# Environment variables for the JPLAG environment
+# JPLAG_LANGUAGE (required) : The programming language to be used for the plagiarism detection. Supported values are available at https://github.com/jplag/JPlag. Be aware of the version used.
+# SIM_THRESHOLD : The similarity threshold for the plagiarism detection. Default is 0 (0% similarity).
+
+
+ARG   VERSION=latest
+ARG   REGISTRY=ghcr.io
+FROM  ${REGISTRY}/inginious/env-base:${VERSION}
+
+LABEL org.opencontainers.image.source=https://github.com/INGInious/containers
+LABEL org.opencontainers.image.description="Single test JPLAG job environment"
+LABEL org.inginious.grading.name="jplag"
+
+
+# Install Java SE 21
+RUN dnf clean metadata && \
+    dnf -y upgrade && \
+    dnf -y install java-21-openjdk-headless
+
+
+# JPlag 6.2.0, last version compatible with Java 21
+ENV JPLAG_VERSION=6.2.0
+ENV JPLAG_JAR=/opt/jplag/jplag-${JPLAG_VERSION}-jar-with-dependencies.jar
+
+RUN mkdir -p /opt/jplag && \
+    curl -L -o "${JPLAG_JAR}" \
+    "https://github.com/jplag/JPlag/releases/download/v${JPLAG_VERSION}/jplag-${JPLAG_VERSION}-jar-with-dependencies.jar"
+
+
+RUN mkdir -p /jplag/input /jplag/submissions /jplag/result /jplag/basecode && \
+    chmod -R 777 /jplag
+
+
+COPY run.py /course/run.py
+COPY test_submissions.zip /jplag/input/submissions.zip

--- a/inginious/frontend/plugins/jplag/container/Dockerfile
+++ b/inginious/frontend/plugins/jplag/container/Dockerfile
@@ -1,8 +1,19 @@
 # DOCKER-VERSION 1.1.0
 
-# Environment variables for the JPLAG environment
-# JPLAG_LANGUAGE (required) : The programming language to be used for the plagiarism detection. Supported values are available at https://github.com/jplag/JPlag. Be aware of the version used.
-# SIM_THRESHOLD : The similarity threshold for the plagiarism detection. Default is 0 (0% similarity).
+# usage outside of INGInious :
+# Create a .zip file containing one directory per student, each containing the student's submission. The .zip file should be named "submissions.zip".
+# Then, run the container with the following command :
+#
+#docker run -v "$(pwd)/test_submissions.zip":/jplag/input/submissions.zip -e JPLAG_LANGUAGE=python3 --entrypoint python3 jplag:latest
+# -c "
+# import sys
+# from unittest.mock import MagicMock
+# sys.modules['inginious_container_api'] = MagicMock()
+# sys.modules['inginious_container_api.feedback'] = MagicMock()
+# exec(open('/course/run.py').read())
+# "
+#
+# The mock is necessary to avoid import errors, as the container expects to be run in an INGInious environment.
 
 
 ARG   VERSION=latest
@@ -34,4 +45,3 @@ RUN mkdir -p /jplag/input /jplag/submissions /jplag/result /jplag/basecode && \
 
 
 COPY run.py /course/run.py
-COPY test_submissions.zip /jplag/input/submissions.zip

--- a/inginious/frontend/plugins/jplag/container/run.py
+++ b/inginious/frontend/plugins/jplag/container/run.py
@@ -1,0 +1,97 @@
+from inginious_container_api import feedback
+import subprocess
+import os
+import zipfile
+
+
+# ─── Paths ────────────────────────────────────────────────────────────────────
+#
+#   ZIP_PATH        : path to the input zip file containing the submissions zip (required)
+#   SUBMISSIONS_DIR : path to the directory where the submissions will be extracted
+#   RESULT_FILE     : path to the JPlag result file (without extension, JPlag will add .jplag)
+#   BASE_CODE_DIR   : path to the directory containing the base code (optional, only if you want to use
+
+ZIP_PATH        = "/jplag/input/submissions.zip"
+SUBMISSIONS_DIR = "/jplag/submissions"
+RESULT_FILE      = "/jplag/result/results.jplag"
+BASE_CODE_DIR   = "/jplag/basecode"
+
+
+# ─── Configuration (environment variables) ────────────────────────────────────
+#
+#   JAVA_JAR        : path to the jplag jar file (required)
+#   JPLAG_LANGUAGE            : e.g. java, python3, cpp, typescript (default: java)
+#   JPLAG_SIMILARITY_THRESHOLD: minimum similarity to store -m (default: 0.0)
+#   JPLAG_SUBDIRECTORY        : scan only this subdir inside each submission (optional)
+
+JAVA_JAR        = os.environ["JPLAG_JAR"]
+LANGUAGE      = os.environ.get("JPLAG_LANGUAGE")
+SIM_THRESHOLD = os.environ.get("JPLAG_SIMILARITY_THRESHOLD")
+
+
+# ─── 1. Extract the submissions zip ───────────────────────────────────────────
+#
+# Supported zip layout:
+#
+# one folder per student:
+#   submissions.zip
+#   ├── alice/
+#   │   └── Solution.java
+#   ├── bob/
+#   │   ├── Main.java
+#   │   └── util/Helper.java
+#   └── charlie/
+#       └── answer.py
+#
+
+if not os.path.isfile(ZIP_PATH):
+    print(f"ERROR: submissions zip not found at '{ZIP_PATH}'.")
+    feedback.set_global_result("failed")
+    raise SystemExit(1)
+
+print(f"Extracting '{ZIP_PATH}' ...")
+with zipfile.ZipFile(ZIP_PATH, "r") as zf:
+    zf.extractall(SUBMISSIONS_DIR)
+print("Extraction complete.")
+
+
+submissions = [
+    d for d in os.listdir(SUBMISSIONS_DIR)
+    if os.path.isdir(os.path.join(SUBMISSIONS_DIR, d)) and not d.startswith("_")
+]
+print(f"Found {len(submissions)} submission(s): {submissions}")
+
+if len(submissions) < 2:
+    print(f"ERROR: at least 2 submissions required, found {len(submissions)}.")
+    feedback.set_global_result("failed")
+    raise SystemExit(1)
+
+
+# ─── 2. Build the JPlag command ────────────────────────────────────────────────
+
+cmd = [
+    "java", "-jar", JAVA_JAR,
+    "--mode", "run",   # not launching the GUI viewer
+    "-l", LANGUAGE,
+    "-r", RESULT_FILE,
+    "--overwrite",
+]
+
+
+if SIM_THRESHOLD:
+    cmd += ["-m", SIM_THRESHOLD]
+if os.path.isdir(BASE_CODE_DIR):
+    cmd += ["-b", BASE_CODE_DIR]
+
+cmd.append(SUBMISSIONS_DIR)
+
+
+# ─── 3. Run JPlag ──────────────────────────────────────────────────────────────
+
+proc = subprocess.run(cmd, capture_output=True, text=True)
+
+
+print("JPlag executed successfully.")
+print(f"Report written to: {RESULT_FILE }.jplag")
+
+feedback.set_global_result("success")


### PR DESCRIPTION
This PR adds a JPLAG Docker environment for later implementation of JPLAG analyses as jobs. This environment takes a zip files containing directories containing files that will be compared by JPLAG. It decompresses it and runs the JPLAG jar.  

JPLAG by default opens a GUI when run to display the results. Here, however, JPLAG only generates the compressed file (.jplag) that can be read afterwards with the same JPLAG jar. [See JPLAG documentation](https://github.com/jplag/JPlag/wiki/7.-Report-Viewer)

To use it outside the INGInious architecture you override the the INGInious script started by the container and replace it with a simple execution of the run script. The result file is saved on the container at `/jplag/result/results.jplag`. Run this docker command to run it. Here we have defined python3 as the language used for the plagiarism detection. A lot of languages are accepted ([see documentation](https://github.com/jplag/JPlag)). 

```sh
docker run  -v "$(pwd)/test_submissions.zip":/jplag/input/submissions.zip   
-e JPLAG_LANGUAGE=python3     
--entrypoint /bin/bash   
jplag:latest   
-c "python3 /course/run.py"
```