### PR TITLE
[agent_docker] appropriate selinux labelling

### DIFF
--- a/doc/admin_doc/install_doc/installation.rst
+++ b/doc/admin_doc/install_doc/installation.rst
@@ -29,9 +29,6 @@ INGInious needs:
 RHEL/Rocky/Alma Linux 8+, Fedora 34+
 `````````````````````````````
 
-.. DANGER::
-    Due to compatibility issues, it is recommended to disable SELinux on the target machine.
-
 The previously mentioned dependencies can be installed, for Cent OS 7+ :
 
 .. code-block:: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,12 +76,12 @@ services:
     environment:
       BACKEND: "tcp://backend:2001"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:z
       # See https://github.com/INGInious/INGInious/issues/352
-      - ./tasks:/inginious/tasks
-      - ./backups:/inginious/backups
+      - ./tasks:/inginious/tasks:z
+      - ./backups:/inginious/backups:z
       # See https://github.com/INGInious/INGInious/issues/799
-      - /tmp/agent_data:/tmp/agent_data
+      - /tmp/agent_data:/tmp/agent_data:z
     networks:
       - inginious
 
@@ -102,10 +102,10 @@ services:
       BACKEND: "tcp://backend:2001"
     volumes:
       # See https://github.com/INGInious/INGInious/issues/352
-      - ./tasks:/inginious/tasks
-      - ./backups:/inginious/backups
+      - ./tasks:/inginious/tasks:z
+      - ./backups:/inginious/backups:z
       # See https://github.com/INGInious/INGInious/issues/799
-      - /tmp/agent_data:/tmp/agent_data
+      - /tmp/agent_data:/tmp/agent_data:z
     networks:
       - inginious
 
@@ -125,9 +125,9 @@ services:
     environment:
       - INGINIOUS_WEBAPP_HOST=0.0.0.0
     volumes:
-      - ./configuration.deploy.yaml:/inginious/configuration.yaml
-      - ./tasks:/inginious/tasks
-      - ./backups:/inginious/backups
+      - ./configuration.deploy.yaml:/inginious/configuration.yaml:z
+      - ./tasks:/inginious/tasks:z
+      - ./backups:/inginious/backups:z
     ports:
       - 9000:8080
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   db:
     image: mongo:6.0.2
     volumes:
-      - ./db:/data/db
+      - ./db:/data/db:z
     networks:
       - inginious
 
@@ -75,6 +75,8 @@ services:
         - REGISTRY=${REGISTRY}
     environment:
       BACKEND: "tcp://backend:2001"
+    security_opt:
+      - "label=disable"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z
       # See https://github.com/INGInious/INGInious/issues/352

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -508,10 +508,10 @@ class DockerAgent(Agent):
                 ports[p] = self._external_ports.pop()
 
             try:
-                socket_path = path_join(parent_info.sockets_path, str(socket_id) + ".sock")
                 container_id = await self._docker.create_container_student(runtime, environment,
                                                                            memory_limit, parent_info.student_path,
-                                                                           socket_path,
+                                                                           parent_info.sockets_path,
+                                                                           socket_id,
                                                                            parent_info.systemfiles_path,
                                                                            parent_info.course_common_student_path,
                                                                            parent_info.environment_type,

--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -7,7 +7,7 @@
     (not asyncio) Interface to Docker
 """
 import os
-from datetime import datetime
+import random
 from typing import List, Tuple, Dict
 
 import docker
@@ -147,27 +147,29 @@ class DockerInterface(object):  # pragma: no cover
             extra_hosts={"host.docker.internal": "host-gateway"},
             environment={"DEBUGGER" : debugger},
             volumes={
-                task_path: {'bind': '/task'},
-                sockets_path: {'bind': '/sockets'},
-                course_common_path: {'bind': '/course/common', 'mode': 'ro'},
-                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro'}
+                task_path: {'bind': '/task', 'mode': 'Z'},
+                sockets_path: {'bind': '/sockets', 'mode': 'Z'},
+                course_common_path: {'bind': '/course/common', 'mode': 'ro,Z'},
+                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro,Z'}
             },
             runtime=runtime,
-            ulimits=[nofile_limit]
+            ulimits=[nofile_limit],
+            security_opt=self._get_security_opts(sockets_path)
         )
         return response.id
 
     def create_container_student(self, runtime: str, image: str, mem_limit, student_path,
-                                 socket_path, systemfiles_path, course_common_student_path,
+                                 sockets_path, socket_id, systemfiles_path, course_common_student_path,
                                  parent_runtime: str,fd_limit, share_network_of_container: str=None, ports=None):
         """
         Creates a student container
         :param fd_limit:Tuple with soft and hard limits per slot for FS
         :param runtime: name of the docker runtime to use
         :param image: env to start (name/id of a docker image)
-        :param mem_limit: in Mo
+        :param mem_limit: in MB
         :param student_path: path to the task directory that will be mounted in the container
-        :param socket_path: path to the socket that will be mounted in the container
+        :param sockets_path: path to the parent container sockets
+        :param socket_id: id of the socket that will be mounted in the container
         :param systemfiles_path: path to the systemfiles folder containing files that can override partially some defined system files
         :param course_common_student_path:
         :param share_network_of_container: (deprecated) if a container id is given, the new container will share its
@@ -176,7 +178,7 @@ class DockerInterface(object):  # pragma: no cover
         :return: the container id
         """
         student_path = os.path.abspath(student_path)
-        socket_path = os.path.abspath(socket_path)
+        parent_socket_path = os.path.abspath(os.path.join(sockets_path, str(socket_id) + ".sock"))
         systemfiles_path = os.path.abspath(systemfiles_path)
         course_common_student_path = os.path.abspath(course_common_student_path)
         secured_scripts_path = student_path+"/scripts"
@@ -204,14 +206,15 @@ class DockerInterface(object):  # pragma: no cover
             network_mode=net_mode,
             ports=ports,
             volumes={
-                student_path: {'bind': '/task/student'},
-                secured_scripts_path: {'bind': '/task/student/scripts'},
-                socket_path: {'bind': '/__parent.sock'},
-                systemfiles_path: {'bind': '/task/systemfiles', 'mode': 'ro'},
-                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro'}
+                student_path: {'bind': '/task/student', 'mode': 'Z'},
+                secured_scripts_path: {'bind': '/task/student/scripts', 'mode': 'Z'},
+                parent_socket_path: {'bind': '/__parent.sock', 'mode': 'Z'},
+                systemfiles_path: {'bind': '/task/systemfiles', 'mode': 'ro,Z'},
+                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro,Z'}
             },
             runtime=runtime,
-            ulimits=[nofile_limit]
+            ulimits=[nofile_limit],
+            security_opt=self._get_security_opts(sockets_path)
         )
 
         return response.id
@@ -275,3 +278,10 @@ class DockerInterface(object):  # pragma: no cover
         :return: dict of runtime: path_to_runtime
         """
         return {name: x["path"] for name, x in self._docker.info()["Runtimes"].items()}
+
+    def _get_security_opts(self, seed: str) -> str:
+        """
+        :return: SELinux MCS label based on the given seed
+        """
+        c1, c2 = random.Random(seed).sample(range(1024), 2)
+        return [f"label=level:s0:c{c1},c{c2}"]


### PR DESCRIPTION
It seems our README has mentioned the code works with SELinux for 11 years without being the case. 

This patch enables SELinux labelling on the mounted volumes. Since a temporary folder is created for each submission, I decided to apply a strict labelling (`Z`) and associates two random MCS categories (as the container runtime does by default) to all containers with the same parent (of the same submission). This allows to share the Unix socket created in the parent container with the student containers.

This last operation is done by using the parent sockets path as the seed for the random function to avoid keeping more state in memory and a more important refactor.

This is probably not perfect, but still better than deactivating SELinux to allow the system to work.

This patch was tested on a system with SELinux disabled at boot time and the options seem to be ignored, so it should be the case on distros that are not shipped with SELinux without further checks.