### PR TITLE
[agent_docker] add support for cgroups v2

### DIFF
--- a/base-containers/base/Dockerfile
+++ b/base-containers/base/Dockerfile
@@ -7,7 +7,7 @@ ENV LC_ALL en_US.UTF-8
 
 LABEL org.opencontainers.image.source=https://github.com/INGInious/containers
 LABEL org.opencontainers.image.description="Base INGInious grading environment."
-LABEL org.inginious.grading.agent_version=3
+LABEL org.inginious.grading.agent_version=4
 
 ARG PYTHON_VERSION=3.14
 ARG LIB_PATH="/usr/lib/python${PYTHON_VERSION}/site-packages"

--- a/base-containers/base/Dockerfile
+++ b/base-containers/base/Dockerfile
@@ -7,7 +7,7 @@ ENV LC_ALL en_US.UTF-8
 
 LABEL org.opencontainers.image.source=https://github.com/INGInious/containers
 LABEL org.opencontainers.image.description="Base INGInious grading environment."
-LABEL org.inginious.grading.agent_version=3
+LABEL org.inginious.grading.agent_version=4
 
 ARG LIB_PATH="/usr/lib/python3.12/site-packages"
 

--- a/base-containers/base/bin/INGInious
+++ b/base-containers/base/bin/INGInious
@@ -353,6 +353,18 @@ class INGIniousMainRunner:
 
         ok_to_start = True
 
+        # Check cgroupsv2 OOM policy
+        oom_group_path = "/sys/fs/cgroup/memory.oom.group"
+        if os.path.exists(oom_group_path):
+            with open(oom_group_path, "r", encoding="utf-8") as f:
+                oom_group = f.read().strip()
+            if oom_group == "0":
+                inginious_container_api.feedback.set_global_result('crash')
+                inginious_container_api.feedback.set_global_feedback(
+                    "Cgroup flag memory.oom.group is not set. Please refer to the setup documentation."
+                )
+                ok_to_start = False
+
         # Add some elements to /etc/hosts and /etc/resolv.conf if needed
         system_files = {"hosts": ("/etc/hosts", True), "resolv.conf": ("/etc/resolv.conf", False)}
         for name, (spath, append) in system_files.items():

--- a/doc/admin_doc/install_doc/installation.rst
+++ b/doc/admin_doc/install_doc/installation.rst
@@ -29,9 +29,6 @@ INGInious needs:
 RHEL/Rocky/Alma Linux 8+, Fedora 34+
 `````````````````````````````
 
-.. DANGER::
-    Due to compatibility issues, it is recommended to disable SELinux on the target machine.
-
 The previously mentioned dependencies can be installed, for Cent OS 7+ :
 
 .. code-block:: bash

--- a/doc/admin_doc/install_doc/installation.rst
+++ b/doc/admin_doc/install_doc/installation.rst
@@ -4,136 +4,109 @@ Installation and deployment
 Supported platforms
 -------------------
 
-INGInious is intended to run on Linux (kernel 3.10+), but can also be run on macOS thanks to the Docker toolbox.
+INGInious runs Linux containers and is therefore intended to run on Linux.
 
-.. NOTE::
-
-    While Docker is supported on Windows 10, INGInious does not provide support for Windows yet. If you are willing to
-    contribute this, feel free to contact us on Github.
+You may be able to run it on other platforms supporting Linux containers, but no support is provided yet.
+If you are willing to contribute this, feel free to contact us on Github.
 
 Dependencies setup
 ------------------
 
 INGInious needs:
 
-- Python_ 3
-- Docker_
+- Python_ 3.10+
+- Docker_ or Podman_
 - MongoDB_
-- Libtidy
-- LibZMQ
 
 .. _Docker: https://www.docker.com
+.. _Podman: https://podman.io/
 .. _Python: https://www.python.org/
 .. _MongoDB: http://www.mongodb.org/
 
-RHEL/Rocky/Alma Linux 8+, Fedora 34+
-`````````````````````````````
+RHEL/Rocky/Alma Linux 8+
+````````````````````````
 
-The previously mentioned dependencies can be installed, for Cent OS 7+ :
+#. The previously mentioned dependencies can be installed:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    # yum install -y epel-release
-    # yum install -y git gcc libtidy python3 python3-devel python3-pip zeromq-devel yum-utils
-    # yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    # yum install -y docker-ce docker-ce-cli
-    # cat <<EOF > /etc/yum.repos.d/mongodb-org-7.0.repo
-    [mongodb-org-7.0]
-    name=MongoDB Repository
-    baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/
-    gpgcheck=1
-    enabled=1
-    gpgkey=https://pgp.mongodb.com/server-7.0.asc
-    EOF
-    # yum install -y mongodb-org mongodb-org-server
+     # dnf install -y epel-release && crb enable
+     # dnf install -y git gcc python3.12 python3.12-devel python3.12-pip dnf-plugins-core
+     # dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+     # yum install -y docker-ce docker-ce-cli
+     # cat <<EOF > /etc/yum.repos.d/mongodb-org-8.0.repo
+     [mongodb-org-8.0]
+     name=MongoDB Repository
+     baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/8.0/x86_64/
+     gpgcheck=1
+     enabled=1
+     gpgkey=https://pgp.mongodb.com/server-8.0.asc
+     EOF
+     # dnf install -y mongodb-org mongodb-org-server
 
-Or, for Fedora 34+:
+   You may also add ``xmlsec1-openssl-devel libtool-ltdl-devel`` for the SAML2 auth plugin.
 
-.. code-block:: bash
+#. You can now enable and start the ``mongod`` and ``docker`` services:
+   ::
 
-    # yum install -y git gcc libtidy python3 python3-devel python3-pip python3-venv zeromq-devel dnf-plugins-core
-    # dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-    # dnf install -y docker-ce docker-ce-cli
-    # cat <<EOF > /etc/yum.repos.d/mongodb-org-7.0.repo
-    [mongodb-org-7.0]
-    name=MongoDB Repository
-    baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/7.0/x86_64/
-    gpgcheck=1
-    enabled=1
-    gpgkey=https://pgp.mongodb.com/server-7.0.asc
-    EOF
-    # yum install -y mongodb-org mongodb-org-server
+      # systemctl enable --now mongod docker
 
-You may also add ``xmlsec1-openssl-devel libtool-ltdl-devel`` for the SAML2 auth plugin.
+#. Check the cgroups version the container runtime is running on:
+   ::
+      # docker info | grep "Cgroup"
+   If the cgroups version is ``2`` and cgroups driver is ``systemd``, apply the following systemd rule:
+   ::
+      # cat /etc/systemd/system/docker-.scope.d/99-inginious.conf
+      [Scope]
+      OOMPolicy=kill
 
-You can now start and enable the ``mongod`` and ``docker`` services:
-::
-
-    # systemctl start mongod
-    # systemctl enable mongod
-    # systemctl start docker
-    # systemctl enable docker
-
-Ubuntu 22.04+
+Ubuntu 24.04+
 `````````````
 
+#. The previously mentioned dependencies can be installed:
 
-The previously mentioned dependencies can be installed, for Ubuntu 22.04+:
+   .. code-block:: bash
 
-As previously said, INGInious needs some specific packages. Those can simply be add by running this command:
+      $ sudo apt install git gcc python3-pip python3-dev python3-venv
+      $ sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+      $ sudo chmod a+r /etc/apt/keyrings/docker.asc
+      $ sudo tee /etc/apt/sources.list.d/docker.sources <<EOF
+      Types: deb
+      URIs: https://download.docker.com/linux/ubuntu
+      Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+      Components: stable
+      Architectures: $(dpkg --print-architecture)
+      Signed-By: /etc/apt/keyrings/docker.asc
+      EOF
+      $ sudo apt update
+      $ sudo apt install docker-ce docker-ce-cli
+      $ curl -fsSL https://pgp.mongodb.com/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+      $ echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+      $ sudo apt update
+      $ sudo apt install mongodb-org
 
-.. code-block:: bash
+   You may also add ``libxmlsec1-dev libltdl-dev`` for the SAML2 auth plugin.
 
-    sudo apt install git gcc tidy python3-pip python3-dev python3-venv libzmq3-dev apt-transport-https
+#. You can now enable and start the ``mongod`` and ``docker`` services:
+   ::
 
-For Docker and MongoDB, some specific steps are needed:
+      # systemctl enable --now mongod docker
 
-First, Docker:
-
-.. code-block:: bash
-
-    sudo apt install curl gnupg lsb-release
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt update
-    sudo apt install docker-ce docker-ce-cli
-
-Then, Mongo:
-
-.. code-block:: bash
-
-    wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
-    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
-    sudo apt update
-    wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-    sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-    sudo apt install -y mongodb-org
-
-.. NOTE::
-
-    Libssl installation is a temporary fix that is not required for all versions.
-    It may not work anymore (or may not be necessary) for future versions.
-
-You may also add ``libxmlsec1-dev libltdl-dev`` for the SAML2 auth plugin.
-
-You can now start and enable the ``mongod`` and ``docker`` services:
-::
-
-    # systemctl daemon-reload
-    # systemctl start mongod
-    # systemctl enable mongod
-    # systemctl start docker
-    # systemctl enable docker
-
-
+#. Check the cgroups version the container runtime is running on:
+   ::
+      # docker info | grep "Cgroup"
+   If the cgroups version is ``2`` and cgroups driver is ``systemd``, apply the following systemd rule:
+   ::
+      # cat /etc/systemd/system/docker-.scope.d/99-inginious.conf
+      [Scope]
+      OOMPolicy=kill
 
 macOS
 `````
 
 .. WARNING::
 
-    While Docker supports both x86 and ARM containers on Apple silicon, compatibility hasn't been tested yet.
-    Feel free to contribute.
+    Documentation for macOS is outdated. Feel free to contribute.
 
 We use brew_ to install some packages. Packages are certainly available too via macPorts.
 

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -230,8 +230,10 @@ class DockerAgent(Agent):
         since = None  # last time we saw something. Useful if a restart happens...
         while not shutdown:
             try:
+                # Catch oom events with cgroups1 only, not to kill twice
+                event_filter = ["die", "oom"] if await self._docker.get_cgroup_version() == "1" else ["die"]
                 source = AsyncIteratorWrapper(
-                    self._docker.sync.event_stream(filters={"event": ["die", "oom"]}, since=since))
+                    self._docker.sync.event_stream(filters={"event": event_filter}, since=since))
                 self._logger.info("Docker event stream started")
                 async for event in source:
                     try:
@@ -247,11 +249,19 @@ class DockerAgent(Agent):
                                 self._logger.exception("Cannot parse exitCode for container %s", container_id)
                                 retval = -1
 
+                            # Check if the container was killed due to OOM.
+                            oom_killed = await self._docker.was_oom_killed(container_id)
+                            if oom_killed and (container_id in self._containers_running or
+                                               container_id in self._student_containers_running):
+                                self._logger.info("Container %s did OOM and was killed.", container_id)
+                                self._containers_killed[container_id] = "overflow"
+
                             if container_id in self._containers_running:
                                 self._create_safe_task(self.handle_job_closing(container_id, retval))
                             elif container_id in self._student_containers_running:
                                 self._create_safe_task(self.handle_student_job_closing(container_id, retval))
                         elif event["Type"] == "container" and event["Action"] == "oom":
+                            # On cgroups v1, the OOM killer is disabled to make sure the whole container is killed.
                             container_id = event["Actor"]["ID"]
                             if container_id in self._containers_running or container_id in self._student_containers_running:
                                 self._logger.info("Container %s did OOM, killing it", container_id)

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -508,10 +508,10 @@ class DockerAgent(Agent):
                 ports[p] = self._external_ports.pop()
 
             try:
-                socket_path = path_join(parent_info.sockets_path, str(socket_id) + ".sock")
                 container_id = await self._docker.create_container_student(runtime, environment,
                                                                            memory_limit, parent_info.student_path,
-                                                                           socket_path,
+                                                                           parent_info.sockets_path,
+                                                                           socket_id,
                                                                            parent_info.systemfiles_path,
                                                                            parent_info.course_common_student_path,
                                                                            parent_info.environment_type,

--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -7,7 +7,7 @@
     (not asyncio) Interface to Docker
 """
 import os
-from datetime import datetime
+import random
 from typing import List, Tuple, Dict
 
 import docker
@@ -147,27 +147,29 @@ class DockerInterface(object):  # pragma: no cover
             extra_hosts={"host.docker.internal": "host-gateway"},
             environment={"DEBUGGER" : debugger},
             volumes={
-                task_path: {'bind': '/task'},
-                sockets_path: {'bind': '/sockets'},
-                course_common_path: {'bind': '/course/common', 'mode': 'ro'},
-                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro'}
+                task_path: {'bind': '/task', 'mode': 'Z'},
+                sockets_path: {'bind': '/sockets', 'mode': 'Z'},
+                course_common_path: {'bind': '/course/common', 'mode': 'ro,Z'},
+                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro,Z'}
             },
             runtime=runtime,
-            ulimits=[nofile_limit]
+            ulimits=[nofile_limit],
+            security_opt=self._get_security_opts(sockets_path)
         )
         return response.id
 
     def create_container_student(self, runtime: str, image: str, mem_limit, student_path,
-                                 socket_path, systemfiles_path, course_common_student_path,
+                                 sockets_path, socket_id, systemfiles_path, course_common_student_path,
                                  parent_runtime: str,fd_limit, share_network_of_container: str=None, ports=None):
         """
         Creates a student container
         :param fd_limit:Tuple with soft and hard limits per slot for FS
         :param runtime: name of the docker runtime to use
         :param image: env to start (name/id of a docker image)
-        :param mem_limit: in Mo
+        :param mem_limit: in MB
         :param student_path: path to the task directory that will be mounted in the container
-        :param socket_path: path to the socket that will be mounted in the container
+        :param sockets_path: path to the parent container sockets
+        :param socket_id: id of the socket that will be mounted in the container
         :param systemfiles_path: path to the systemfiles folder containing files that can override partially some defined system files
         :param course_common_student_path:
         :param share_network_of_container: (deprecated) if a container id is given, the new container will share its
@@ -176,7 +178,7 @@ class DockerInterface(object):  # pragma: no cover
         :return: the container id
         """
         student_path = os.path.abspath(student_path)
-        socket_path = os.path.abspath(socket_path)
+        parent_socket_path = os.path.abspath(os.path.join(sockets_path, str(socket_id) + ".sock"))
         systemfiles_path = os.path.abspath(systemfiles_path)
         course_common_student_path = os.path.abspath(course_common_student_path)
         secured_scripts_path = student_path+"/scripts"
@@ -204,14 +206,15 @@ class DockerInterface(object):  # pragma: no cover
             network_mode=net_mode,
             ports=ports,
             volumes={
-                student_path: {'bind': '/task/student'},
-                secured_scripts_path: {'bind': '/task/student/scripts'},
-                socket_path: {'bind': '/__parent.sock'},
-                systemfiles_path: {'bind': '/task/systemfiles', 'mode': 'ro'},
-                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro'}
+                student_path: {'bind': '/task/student', 'mode': 'Z'},
+                secured_scripts_path: {'bind': '/task/student/scripts', 'mode': 'Z'},
+                parent_socket_path: {'bind': '/__parent.sock', 'mode': 'Z'},
+                systemfiles_path: {'bind': '/task/systemfiles', 'mode': 'ro,Z'},
+                course_common_student_path: {'bind': '/course/common/student', 'mode': 'ro,Z'}
             },
             runtime=runtime,
-            ulimits=[nofile_limit]
+            ulimits=[nofile_limit],
+            security_opt=self._get_security_opts(sockets_path)
         )
 
         return response.id
@@ -275,3 +278,10 @@ class DockerInterface(object):  # pragma: no cover
         :return: dict of runtime: path_to_runtime
         """
         return {name: x["path"] for name, x in self._docker.info()["Runtimes"].items()}
+
+    def _get_security_opts(self, seed: str) -> str:
+        """
+        :return: SELinux MCS label based on the given seed
+        """
+        c1, c2 = random.Random(seed).sample(range(1024), 2)
+        return [f"label=level:s0:c{c1},c{c2}"]

--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -17,7 +17,7 @@ from docker.types import Ulimit
 
 from inginious.agent.docker_agent._docker_runtime import DockerRuntime
 
-DOCKER_AGENT_VERSION = 3
+DOCKER_AGENT_VERSION = 4
 
 
 class DockerInterface(object):  # pragma: no cover
@@ -30,6 +30,12 @@ class DockerInterface(object):  # pragma: no cover
     @property
     def _docker(self):
         return docker.from_env()
+
+    def get_cgroup_version(self) -> str:
+        """
+        :return: the cgroup version, that is, "1" or "2".
+        """
+        return self._docker.info().get("CgroupVersion")
     
     def get_containers(self, runtimes: List[DockerRuntime]) -> Dict[str, Dict[str, Dict[str, str]]]:
         """
@@ -135,13 +141,15 @@ class DockerInterface(object):  # pragma: no cover
 
         nofile_limit = Ulimit(name='nofile', soft=fd_limit[0], hard=fd_limit[1])
 
+        cgroups1_params = {
+            "mem_swappiness": 0, "oom_kill_disable": True
+        } if self.get_cgroup_version() == "1" else {}
+
         response = self._docker.containers.create(
             image,
             stdin_open=True,
             mem_limit=str(mem_limit) + "M",
             memswap_limit=str(mem_limit) + "M",
-            mem_swappiness=0,
-            oom_kill_disable=True,
             network_mode=("bridge" if (network_grading or len(ports) > 0) else 'none'),
             ports=ports,
             extra_hosts={"host.docker.internal": "host-gateway"},
@@ -154,7 +162,8 @@ class DockerInterface(object):  # pragma: no cover
             },
             runtime=runtime,
             ulimits=[nofile_limit],
-            security_opt=self._get_security_opts(sockets_path)
+            security_opt=self._get_security_opts(sockets_path),
+            **cgroups1_params
         )
         return response.id
 
@@ -195,14 +204,16 @@ class DockerInterface(object):  # pragma: no cover
 
         nofile_limit = Ulimit(name='nofile', soft=fd_limit[0], hard=fd_limit[1])
 
+        cgroups1_params = {
+            "mem_swappiness": 0, "oom_kill_disable": True
+        } if self.get_cgroup_version() == "1" else {}
+
         response = self._docker.containers.create(
             image,
             stdin_open=True,
             command="_run_student_intern "+runtime + " " + parent_runtime,  # the script takes the runtimes as arguments
             mem_limit=str(mem_limit) + "M",
             memswap_limit=str(mem_limit) + "M",
-            mem_swappiness=0,
-            oom_kill_disable=True,
             network_mode=net_mode,
             ports=ports,
             volumes={
@@ -214,7 +225,8 @@ class DockerInterface(object):  # pragma: no cover
             },
             runtime=runtime,
             ulimits=[nofile_limit],
-            security_opt=self._get_security_opts(sockets_path)
+            security_opt=self._get_security_opts(sockets_path),
+            **cgroups1_params
         )
 
         return response.id
@@ -262,6 +274,13 @@ class DockerInterface(object):  # pragma: no cover
         :param signal: custom signal. Default is SIGKILL.
         """
         self._docker.containers.get(container_id).kill(signal)
+
+    def was_oom_killed(self, container_id):
+        """
+        :param container_id:
+        :return: True if the container was killed by the OOM killer, False otherwise
+        """
+        return self._docker.containers.get(container_id).attrs['State'].get('OOMKilled', False)
 
     def event_stream(self, filters=None, since=None):
         """


### PR DESCRIPTION
This PR follows #1115 and adds full support for cgroups v2. It preserves the cgroups v1 support as this is still the default in some RHEL versions.

- The Docker interface file is modified to detect the cgroups version return by the Docker API
- With cgroups v1, the OOM Killer is disabled. OOM is caught in Docker events, and the container is then killed by INGInious.
- With cgroups v2, the container checks if `memory.oom.group` set to 1 to ensure all the container tasks are killed by the OOM killer once one it runs out of memory, since the OOM killer cannot be disabled anymore. This results in the container being killed by the system and INGInious checking if it died from OOM.
- The documentation is updated and now explains how to ensure systemd set the  `memory.oom.group` flag to 1 for containers spawned by the Docker daemon.

This full support for cgroups v2 allows to runs the code with rootless podman socket set as `DOCKER_HOST`. Since podman does not support enumerating container runtimes from the API and that podman-py does not implement container attach yet, I suggest to keep Docker as the recommended runtime for now, yet I mention it is compatible in the doc.