### PR TITLE
Wrong "_id" key for Submission Document

### DIFF
--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -49,7 +49,7 @@ def _get_submissions(submission_manager, user_manager, courseid, taskid, with_in
             show_everything=user_manager.has_staff_rights_on_course(course, session.username)
         )
         data = {
-            "id": str(submission["_id"]),
+            "id": str(submission["id"]),
             "submitted_on": submission["submitted_on"].isoformat(),
             "status": submission["status"]
         }

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -62,7 +62,7 @@ class INGIniousSubmissionsAdminPage(INGIniousAdminPage):
         audiences = self.user_manager.get_course_audiences(course)
         tasks = course.get_task_dispenser().get_ordered_tasks()
 
-        tutored_audiences = [str(audience["_id"]) for audience in audiences if
+        tutored_audiences = [str(audience["id"]) for audience in audiences if
                              session.username in audience["tutors"]]
         tutored_users = []
         for audience in audiences:
@@ -94,7 +94,7 @@ class INGIniousSubmissionsAdminPage(INGIniousAdminPage):
         # Sanitise audiences
         if len(user_input.get("audiences", [])) == 1 and "," in user_input["audiences"][0]:
             user_input["audiences"] = user_input["audiences"][0].split(',')
-        user_input["audiences"] = [audience for audience in user_input["audiences"] if any(str(a["_id"]) == audience for a in audiences)]
+        user_input["audiences"] = [audience for audience in user_input["audiences"] if any(str(a["id"]) == audience for a in audiences)]
 
         # Sanitise tasks
         if not user_input.get("tasks", []):

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -523,7 +523,7 @@ class WebAppSubmissionManager:
             elif remaining_sub_folders[0] == "group":
                 yield from generate_paths(sub, path + ['-'.join(sorted(sub['username']))], remaining_sub_folders[1:])
             elif remaining_sub_folders[0] == "submissionid":
-                yield from generate_paths(sub, path + [str(sub['_id'])], remaining_sub_folders[1:])
+                yield from generate_paths(sub, path + [str(sub['id'])], remaining_sub_folders[1:])
             elif remaining_sub_folders[0] == "submissiondateid":
                 yield from generate_paths(sub, path + [(sub['submitted_on']).isoformat()], remaining_sub_folders[1:])
             else:

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -373,7 +373,7 @@ class WebAppSubmissionManager:
                                                                      show_everything).parse())
                     except TypeError:
                         self._logger.error(
-                            "Something went wrong with provided feedback for submission %s", str(submission["_id"])
+                            "Something went wrong with provided feedback for submission %s", str(submission["id"])
                             )
                         submission["problems"][problem] = (
                             'crash', ParsableText(_("Feedback is badly formatted."),"rst", show_everything).parse())
@@ -516,7 +516,7 @@ class WebAppSubmissionManager:
                     if username in student_audiences:
                         for audience in student_audiences[username]:
                             yield from generate_paths(sub, path +
-                                                      [(audience["description"] +" (" + str(audience["_id"]) + ")").replace(" ", "_")],
+                                                      [(audience["description"] +" (" + str(audience["id"]) + ")").replace(" ", "_")],
                                                       remaining_sub_folders[1:])
                     else:
                         yield from generate_paths(sub, path + ['-'.join(sorted(sub['username']))], remaining_sub_folders[1:])

--- a/inginious/frontend/templates/course_register.html
+++ b/inginious/frontend/templates/course_register.html
@@ -7,7 +7,7 @@
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="{{ url_for('courselistpage') }}" title="{{ _('Course list') }}" data-toggle="tooltip" data-placement="bottom"><i class="fa fa-th-list"></i></a></li>
-            <li class="breadcrumb-item"><a href="{{ url_for('courseage', courseid=course.get_id()) }}">{{ course.get_name(session.language) }}<span class="sr-only">{{ _("(current)") }}</span></a></li>
+            <li class="breadcrumb-item"><a href="{{ url_for('coursepage', courseid=course.get_id()) }}">{{ course.get_name(session.language) }}<span class="sr-only">{{ _("(current)") }}</span></a></li>
             <li class="breadcrumb-item active"><a href="#">{{ _("Register") }}</a></li>
         </ol>
     </nav>

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -554,7 +554,7 @@ class UserManager:
                 old_submission.state = def_sub["state"]
                 old_submission.submissionid = def_sub.id
                 old_submission.save()
-            elif old_submission.submissionid == submission["_id"]: # otherwise, update cache if needed
+            elif old_submission.submissionid == submission["id"]: # otherwise, update cache if needed
                 old_submission.succeeded = submission["result"] == "success"
                 old_submission.grade = submission["grade"]
                 old_submission.state = submission["state"]


### PR DESCRIPTION
There are multiple places where the id of a submission or audience is accessed with the wrong key ("_id" instead of "id"). The use of the correct key depends if the document is used or if it was a direct call to MongoDB. That's why "_id" is kept in some places.

Also, a small typo in `url_for('courseage'...`.