### PR TITLE
[frontend/pages] Fix old use of get_path() instead of url_for()

### DIFF
--- a/inginious/frontend/pages/mycourses.py
+++ b/inginious/frontend/pages/mycourses.py
@@ -5,7 +5,7 @@
 
 """ Index page """
 from collections import OrderedDict
-from flask import session, request, render_template
+from flask import session, request, render_template, url_for
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 
@@ -47,7 +47,7 @@ class MyCoursesPage(INGIniousAuthPage):
                     "is_lti" : course.is_lti(),
                     "lti_url" : course.lti_url(),
                     "name": course.get_name(session.language),
-                    "path": self.app.get_path("course", courseid),
+                    "path": url_for("coursepage", courseid=courseid),
                     "description": str(course.get_description(session.language))
                 }
                 return pin_html_data


### PR DESCRIPTION
Fixes #1131 

An occurrence of the old `get_path()` remained. Changed to use `url_for()`.