### PR TITLE
Fix crash with empty course staff lists

### DIFF
--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -59,8 +59,8 @@ class Course(object):
             raise Exception("That course is not allowed to be displayed directly in the webapp")
 
         try:
-            self._admins = self._content.get('admins', [])
-            self._tutors = self._content.get('tutors', [])
+            self._admins = self._content.get('admins') or []
+            self._tutors = self._content.get('tutors') or []
             self._description = self._content.get('description', '')
             self._accessible = AccessibleTime(self._content.get("accessible", None))
             self._registration = AccessibleTime(self._content.get("registration", None))

--- a/inginious/frontend/tests/test_course.py
+++ b/inginious/frontend/tests/test_course.py
@@ -101,6 +101,13 @@ class TestCourse(object):
         t = c.get_tasks()
         assert t == {}
 
+    def test_empty_staff_lists(self, ressource):
+        c = Course("empty-staff", {"name": "Empty staff", "admins": None, "tutors": None})
+
+        assert c.get_admins() == []
+        assert c.get_tutors() == []
+        assert c.get_staff() == []
+
 
 class TestCourseWrite(object):
     """ Test the course update function """


### PR DESCRIPTION
Closes https://github.com/INGInious/INGInious/issues/1104

Course configuration now treats explicit null `admins` and `tutors` values like omitted lists, preventing staff-rights checks from crashing while loading the “My courses” page. The focused course test file passes, including a regression covering both null fields.
