### PR TITLE
[backend/agents] replace deprecated ZMQEventLoop with asyncio's default loop

### DIFF
--- a/inginious/frontend/arch_helper.py
+++ b/inginious/frontend/arch_helper.py
@@ -16,9 +16,6 @@ def start_asyncio_and_zmq(debug_asyncio=False):
     """ Init asyncio and ZMQ. Starts a daemon thread in which the asyncio loops run.
     :return: a ZMQ context and a Thread object (as a tuple)
     """
-    # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
-    # sockets work with the regular asyncio event loop, no special
-    # integration is needed anymore.
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if debug_asyncio:

--- a/inginious/frontend/arch_helper.py
+++ b/inginious/frontend/arch_helper.py
@@ -8,7 +8,7 @@ import asyncio
 import multiprocessing
 import threading
 
-from zmq.asyncio import ZMQEventLoop, Context
+from zmq.asyncio import Context
 
 from inginious.client.client import Client
 
@@ -16,7 +16,10 @@ def start_asyncio_and_zmq(debug_asyncio=False):
     """ Init asyncio and ZMQ. Starts a daemon thread in which the asyncio loops run.
     :return: a ZMQ context and a Thread object (as a tuple)
     """
-    loop = ZMQEventLoop()
+    # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
+    # sockets work with the regular asyncio event loop, no special
+    # integration is needed anymore.
+    loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if debug_asyncio:
         loop.set_debug(True)

--- a/inginious/scripts/agent_docker.py
+++ b/inginious/scripts/agent_docker.py
@@ -119,7 +119,6 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:

--- a/inginious/scripts/agent_docker.py
+++ b/inginious/scripts/agent_docker.py
@@ -119,9 +119,7 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
-        # sockets work with the regular asyncio event loop, no special
-        # integration is needed anymore.
+        # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:

--- a/inginious/scripts/agent_docker.py
+++ b/inginious/scripts/agent_docker.py
@@ -13,7 +13,7 @@ import os
 import multiprocessing
 
 import sys
-from zmq.asyncio import ZMQEventLoop, Context
+from zmq.asyncio import Context
 import asyncio
 
 from inginious.common.filesystems import init_fs_provider
@@ -119,7 +119,10 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        loop = ZMQEventLoop()
+        # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
+        # sockets work with the regular asyncio event loop, no special
+        # integration is needed anymore.
+        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:
             loop.set_debug(True)

--- a/inginious/scripts/agent_mcq.py
+++ b/inginious/scripts/agent_mcq.py
@@ -10,7 +10,7 @@
 import argparse
 import logging
 
-from zmq.asyncio import ZMQEventLoop, Context
+from zmq.asyncio import Context
 import asyncio
 
 from inginious.common.entrypoints import get_args_and_filesystem
@@ -67,7 +67,10 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        loop = ZMQEventLoop()
+        # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
+        # sockets work with the regular asyncio event loop, no special
+        # integration is needed anymore.
+        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:
             loop.set_debug(True)

--- a/inginious/scripts/agent_mcq.py
+++ b/inginious/scripts/agent_mcq.py
@@ -67,9 +67,7 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
-        # sockets work with the regular asyncio event loop, no special
-        # integration is needed anymore.
+        # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:

--- a/inginious/scripts/agent_mcq.py
+++ b/inginious/scripts/agent_mcq.py
@@ -67,7 +67,6 @@ def main():
     closing = False
     while not closing:
         # start asyncio and zmq
-        # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         if args.debugmode:

--- a/inginious/scripts/backend.py
+++ b/inginious/scripts/backend.py
@@ -36,7 +36,6 @@ def main():
     logger.addHandler(ch)
 
     # start asyncio and zmq
-    # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if args.debugmode:

--- a/inginious/scripts/backend.py
+++ b/inginious/scripts/backend.py
@@ -36,9 +36,7 @@ def main():
     logger.addHandler(ch)
 
     # start asyncio and zmq
-    # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
-    # sockets work with the regular asyncio event loop, no special
-    # integration is needed anymore.
+    # See inginious/frontend/arch_helper.py for why ZMQEventLoop is no longer used.
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if args.debugmode:

--- a/inginious/scripts/backend.py
+++ b/inginious/scripts/backend.py
@@ -10,7 +10,7 @@
 import argparse
 import logging
 
-from zmq.asyncio import ZMQEventLoop, Context
+from zmq.asyncio import Context
 import asyncio
 
 from inginious.backend.backend import Backend
@@ -36,7 +36,10 @@ def main():
     logger.addHandler(ch)
 
     # start asyncio and zmq
-    loop = ZMQEventLoop()
+    # ZMQEventLoop/zmq.asyncio.install() are deprecated since pyzmq 17: zmq
+    # sockets work with the regular asyncio event loop, no special
+    # integration is needed anymore.
+    loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     if args.debugmode:
         loop.set_debug(True)


### PR DESCRIPTION
Fixes #800

## Problem

`zmq.asyncio.ZMQEventLoop` and `zmq.asyncio.install()` have been deprecated since pyzmq 17, and every backend/agent process prints this warning on startup:

```
inginious-backend:39: DeprecationWarning: ZMQEventLoop and zmq.asyncio.install are deprecated in pyzmq 17. Special eventloop integration is no longer needed.
  loop = ZMQEventLoop()
```

Since pyzmq 17, `zmq.asyncio` sockets work directly with the regular asyncio event loop, so the special `ZMQEventLoop` subclass is unnecessary.

## Fix

Replaced `loop = ZMQEventLoop()` with `loop = asyncio.new_event_loop()` (and dropped the now-unused `ZMQEventLoop` import) in all four places that had this pattern:

- `inginious/scripts/backend.py`
- `inginious/scripts/agent_mcq.py`
- `inginious/scripts/agent_docker.py`
- `inginious/frontend/arch_helper.py` (the local-arch helper used when `BACKEND: local`)

`zmq.asyncio.Context()` and everything downstream (`loop.set_debug()`, `loop.run_until_complete()`, `loop.close()`, `context.destroy()`) is unchanged — only the loop construction changes.

## Test plan

These are process entrypoints that open real ZMQ sockets/Docker, so there's no existing unit test harness for them. I verified the fix directly against `pyzmq` (26.2.1):

- **RED**: constructing `zmq.asyncio.ZMQEventLoop()` under `warnings.catch_warnings(record=True)` reproduces the exact `DeprecationWarning` from the issue.
- **GREEN**: with the new `asyncio.new_event_loop()` + `zmq.asyncio.Context()` pattern, a REQ/REP round-trip over `inproc://` completes successfully with zero `DeprecationWarning`s raised.
- `python -m py_compile` on all four changed files succeeds.

I did not touch `zmq.asyncio.Context()` usage or any other part of the async lifecycle in these files — scope is limited to the deprecated loop construction call, as requested in the issue.