### PR TITLE
Fix empty course staff lists

### DIFF
--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -59,8 +59,8 @@ class Course(object):
             raise Exception("That course is not allowed to be displayed directly in the webapp")
 
         try:
-            self._admins = self._content.get('admins', [])
-            self._tutors = self._content.get('tutors', [])
+            self._admins = self._content.get('admins') or []
+            self._tutors = self._content.get('tutors') or []
             self._description = self._content.get('description', '')
             self._accessible = AccessibleTime(self._content.get("accessible", None))
             self._registration = AccessibleTime(self._content.get("registration", None))

--- a/inginious/frontend/tests/test_course.py
+++ b/inginious/frontend/tests/test_course.py
@@ -101,6 +101,34 @@ class TestCourse(object):
         t = c.get_tasks()
         assert t == {}
 
+    def test_empty_course_tutors_are_treated_as_empty(self, monkeypatch):
+        class DummyFSProvider:
+            def from_subfolder(self, courseid):
+                return self
+
+            def exists(self):
+                return False
+
+        monkeypatch.setattr("inginious.frontend.courses.get_fs_provider", lambda: DummyFSProvider())
+        course = Course("empty-staff", {"name": "Empty staff", "admins": ["admin"], "tutors": None})
+
+        assert course.get_tutors() == []  # nosec B101 - pytest assertion
+        assert course.get_staff() == ["admin"]  # nosec B101 - pytest assertion
+
+    def test_empty_course_admins_are_treated_as_empty(self, monkeypatch):
+        class DummyFSProvider:
+            def from_subfolder(self, courseid):
+                return self
+
+            def exists(self):
+                return False
+
+        monkeypatch.setattr("inginious.frontend.courses.get_fs_provider", lambda: DummyFSProvider())
+        course = Course("empty-admins", {"name": "Empty admins", "admins": None, "tutors": ["tutor"]})
+
+        assert course.get_admins() == []  # nosec B101 - pytest assertion
+        assert course.get_staff() == ["tutor"]  # nosec B101 - pytest assertion
+
 
 class TestCourseWrite(object):
     """ Test the course update function """


### PR DESCRIPTION
## Summary

- treat empty `admins:` and `tutors:` YAML keys as empty lists when loading a course
- add dedicated regression tests for empty tutors and empty admins values

Closes #1104.

## Verification

- `pytest inginious/frontend/tests/test_course.py -q -k 'empty_course_tutors_are_treated_as_empty or empty_course_admins_are_treated_as_empty'`
- `pytest inginious/frontend/tests/test_course.py -q`
- `python -m py_compile inginious/frontend/courses.py inginious/frontend/tests/test_course.py`
- `git diff --check`