### PR TITLE
[frontend/templates] give correctly formatted langauge code to DateTimeFormat constructor

### DIFF
--- a/inginious/frontend/templates/layout.html
+++ b/inginious/frontend/templates/layout.html
@@ -223,7 +223,7 @@
     {% endfor %}
     <script>
         user_indentation_type = {{ config.INDENTATION_TYPES[session.code_indentation] | tojson }};
-        dtf = new Intl.DateTimeFormat({{ session.language | tojson }}, {
+        dtf = new Intl.DateTimeFormat([moment.locale({{ session.language | tojson }}), "en"], {
         dateStyle: "short",
         timeStyle: "medium",
         timeZone: {{ session.timezone | tojson }},


### PR DESCRIPTION
In `frontend/i18n/__init__.py`, which controls the set of available languages, the languages are referred to as `en`, `fr`, `es`, etc. The Norwegian translation is listed as `nb_NO`. The output of `pybabel --list-locales` also uses underscores.

The constructor for `Intl.DateTimeFormat` in JavaScript, however, requires the underscore to be a dash. It will only accept `nb-NO` (or `nb`).

Norwegian is currently the only language with this problem, as we are the only entry in the `available_languages` dict that uses a full locale code, and not just a language code. It looks like someone was considering a Brazilian Portuguese at some point, however. I personally am also more familiar with seeing `nb_NO` than just `nb`.

My proposed fix in this PR is to first give the locale string to the JavaScript library `moment.js`, which is already included in the layout template.
It "normalizes" strings like "nb_NO"->"nb", and "en_GB"->"en-gb".
For unknown locales it falls back to re-returning the last valid locale, or `"en"` as a final fallback.

The constructor for `Intl.DateTimeFormat` can also take a fallback, so this PR adds `"en"` there too.

If we would prefer to avoid using `moment.js`, another option is to perform a direct string replacement of "_" to "-":
```js
dtf = new Intl.DateTimeFormat([{{ session.language | replace("_", "-") | tojson }}, "en"], {
```

I did a quick `git grep session.language`, and the only other place I saw the language string "leak" from the python code was when opening date-time-pickers. The date-time-picker library already uses `moment.locale()` under the hood, so I left them alone.