### PR TITLE
deploy: Fix duplicate superadmin insertion on DB init.

### DIFF
--- a/deploy/db_setup.py
+++ b/deploy/db_setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from pymongo import MongoClient
 from gridfs import GridFS
 
@@ -41,6 +43,12 @@ if __name__ == '__main__':
 
     database = try_mongodb_opts('db')
 
+    # Test whether the superadmin is already set.
+    if database.users.find_one({"username": username}) is not None:
+        print('Superadmin user is already set in the database.')
+        sys.exit()
+
+    # Set new superadmin user.
     database.users.insert_one({"username": username,
                                "realname": realname,
                                "email": email,


### PR DESCRIPTION
Since 11a6873ef393afffa9cd2a4bf5020c5acdaf2cfe, the database of docker-compose based deployments is persitent on the host disk. Because the db_setup.py script is launched at each deployment, the superadmin user was added multiple times in the DB.

This commit fixes the issue by first testing the existence of the superadmin before adding it.