### PR TITLE
Add persistent docker compose db directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ venv
 inginious/tasks
 # Default backup directory
 inginious/backup
+# default db directory for docker compose
+db
 
 # Build files
 build/lib


### PR DESCRIPTION
Add `db` directory, used for docker compose database persistency, to .gitignore file. 
