### PR TITLE
Task soft submission limit with only hours given raises no error

### DIFF
--- a/inginious/frontend/task_dispensers/util.py
+++ b/inginious/frontend/task_dispensers/util.py
@@ -172,6 +172,8 @@ class SubmissionLimit(TaskConfigItem):
         submission_limit = task_config.get(cls.get_id(), cls.default)
         if not type(submission_limit["amount"]) == int or not type(submission_limit["period"]) == int:
             raise InvalidTocException("Invalid submission limit")
+        elif submission_limit["amount"] == -1 and submission_limit["period"] != -1:
+            raise InvalidTocException("You have given a period but no amount for the submission limit")
         elif submission_limit["amount"] < -1 or submission_limit["period"] < -1:
             raise InvalidTocException("Submission limit values must be higher than or equal to -1")
         return submission_limit


### PR DESCRIPTION
This PR fixes a bug in task settings. When selecting soft limit with hours but no number for submissions limit. The hours are stored but the number of submissions is -1. No error arises. In practice, the task behaves like there is no submission limit.