### PR TITLE
Allow empty categories input in task settings

### DIFF
--- a/inginious/frontend/templates/course_admin/task_dispensers/config_items/categories.html
+++ b/inginious/frontend/templates/course_admin/task_dispensers/config_items/categories.html
@@ -31,7 +31,7 @@
 
         tasks.each(function () {
             var taskid = $(this).data("taskid");
-            dispenser_config[taskid]["categories"] = value.split(",");
+            dispenser_config[taskid]["categories"] = value.split(",").filter(item => item !== "");
             $("#task_" + taskid + " .categories-span").text(value);
         });
     });


### PR DESCRIPTION
In the task settings, removing all categories from a task would not work because it would reject empty tags strings. I removed that restriction and made sure `Categories.get_values()` does not return those empty strings. The problem is those empty strings still show up in the `course.yaml`.

Changing the `parse_tasks_config()` method to allow updating the configuration could fix that but it causes multiple issues in other places. Would you like me to address those or do you think having empty string tags in the course.yaml is acceptable.