### PR TITLE
Fix typo in course_unregister_user

### DIFF
--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -692,7 +692,7 @@ class UserManager:
         Audience.objects(courseid=course_id, students=username).update(pull__students=username)
 
         # If user doesn't belong to a group, will ensure correct deletion
-        Group.objects(courseid=course_id, students=username).update(pull_students=username)
+        Group.objects(courseid=course_id, students=username).update(pull__students=username)
 
         CourseClass.objects(id=course_id).update(pull__students=username)
 


### PR DESCRIPTION
This typo fixed a number of bugs : 
- deleting a user would not delete it from the courses they were subsribed to 
- confirming deletion would not redirect/close the modal
- deleting a user from a course would not work but it would delete it from an audience