### PR TITLE
Fix redirection to audiences tab in user management in course settings

### DIFF
--- a/inginious/frontend/pages/course_admin/student_list.py
+++ b/inginious/frontend/pages/course_admin/student_list.py
@@ -255,7 +255,7 @@ class CourseStudentListPage(INGIniousAdminPage):
                             existing_audience.tutors = audience["tutors"]
                             existing_audience.save()
 
-            active_tab = "tab_audiences"
+                active_tab = "tab_audiences"
         except Exception as e:
             msg["audiences"] = _('An error occurred while parsing the data.')
             error["audiences"] = True


### PR DESCRIPTION
This corrects the redirect in the user management settings of a course. When adding or removing a student to the course the user was redirected to the audiences tab. This was due to an indentation error in the process determining what was the active tab.