### PR TITLE
[frontend/courses] Treat empty course.yaml values as absent keys

### DIFF
--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -57,8 +57,9 @@ class Course(object):
             raise Exception("That course is not allowed to be displayed directly in the webapp")
 
         try:
-            self._admins = self._content.get('admins', [])
-            self._tutors = self._content.get('tutors', [])
+            # A key present in the YAML with no value parses to None, so get()'s default does not apply.
+            self._admins = self._content.get('admins') or []
+            self._tutors = self._content.get('tutors') or []
             self._description = self._content.get('description', '')
             self._accessible = AccessibleTime(self._content.get("accessible", None))
             self._registration = AccessibleTime(self._content.get("registration", None))
@@ -67,7 +68,7 @@ class Course(object):
             if self._registration_ac not in [None, "username", "binding", "email"]:
                 raise Exception("Course has an invalid value for registration_ac: " + self.get_id())
             self._registration_ac_accept = self._content.get('registration_ac_accept', True)
-            self._registration_ac_list = self._content.get('registration_ac_list', [])
+            self._registration_ac_list = self._content.get('registration_ac_list') or []
             self._groups_student_choice = self._content.get("groups_student_choice", False)
             self._allow_unregister = self._content.get('allow_unregister', True)
             self._allow_preview = self._content.get('allow_preview', False)

--- a/inginious/frontend/tests/test_course.py
+++ b/inginious/frontend/tests/test_course.py
@@ -101,6 +101,24 @@ class TestCourse(object):
         t = c.get_tasks()
         assert t == {}
 
+    def test_empty_tutors_field(self, ressource):
+        """A 'tutors' key present but with no value must behave like an absent one"""
+        c = Course("test", {"name": "Unit test", "admins": ["testadmin1"], "tutors": None})
+        assert c.get_tutors() == []
+        assert sorted(c.get_staff()) == ["testadmin1"]
+
+    def test_empty_admins_field(self, ressource):
+        """An 'admins' key present but with no value must behave like an absent one"""
+        c = Course("test", {"name": "Unit test", "admins": None, "tutors": ["testtutor1"]})
+        assert c.get_admins() == []
+        assert sorted(c.get_staff()) == ["testtutor1"]
+
+    def test_empty_registration_ac_list_field(self, ressource):
+        """A 'registration_ac_list' key present but with no value must behave like an absent one"""
+        c = Course("test", {"name": "Unit test", "admins": ["testadmin1"],
+                            "registration_ac": "username", "registration_ac_list": None})
+        assert c.get_access_control_list() == []
+
 
 class TestCourseWrite(object):
     """ Test the course update function """


### PR DESCRIPTION
Fixes #1104.

### The bug

A key present in `course.yaml` with no value is parsed as `None` by YAML. `dict.get(key, default)` only falls back to its default when the key is **absent**, so the stored `None` was returned instead:

```yaml
tutors:      # present, but empty -> None, not []
```

`get_staff()` then does `self.get_tutors() + self.get_admins()` and raises:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'
```

Because `has_staff_rights_on_course()` calls `get_staff()` unconditionally, this broke the "My courses" page for **every** user, not just the staff of the affected course.

### The fix

Three `.get(key, [])` calls in `Course.__init__` become `.get(key) or []`. This matches how the codebase already handles the same YAML quirk elsewhere, e.g. `content.get("header", "") or ""` in `inginious/common/tasks_problems.py` and `dispenser_data or {...}` in `task_dispensers/toc.py`.

### Why `registration_ac_list` is included

The issue mentions that "other config parameters might be in the same situation", so I probed every container-typed `.get()` in `Course.__init__` with a `None` value. Only three actually break:

| key | result with an empty value |
|---|---|
| `tutors`, `admins` | `TypeError` in `get_staff()` — the reported crash |
| `registration_ac_list` | `TypeError` in `_build_ac_regex()` |

`registration_ac_list` is read at line 108, **outside** the `try`/`except`, so there is no "invalid YAML spec" wrapper: the raw `TypeError` escapes `Course.__init__`, `get_all()` swallows it as `"Cannot open course"`, and the course silently disappears from the site.

One consequence worth stating explicitly: an empty `registration_ac_list` now yields an empty regex, so with `registration_ac_accept: false` (a deny list) nobody is denied. That is identical to omitting the key entirely, so it is consistent with the existing semantics, but it does mean this turns "course fails to load" into "access control is empty". Happy to error on the empty case instead if you would rather it be loud.

### Deliberately left alone

`tags`, `lti_keys`, `lti_config`, `lti_secrets` and `dispenser_data` have the same `.get()` shape, but they either survive as `None` harmlessly or fail inside the `try`/`except` and degrade to the existing `"Course has an invalid YAML spec"` error rather than an unhandled crash. I kept this PR to the three that produce an unhandled `TypeError`. Glad to extend it to the rest if you would prefer them handled uniformly.

### Tests

Three regression tests in `inginious/frontend/tests/test_course.py`, each confirmed to fail on the unpatched code with the `TypeError` above and pass after. The tutors/admins tests populate the *other* field so that a fix touching only one of them still fails the other test.

Full suite run locally on Python 3.14: 84 passed. The one failure, `inginious/scripts/task_tester/test_anonymizer.py::test_simple_configuration`, also fails on a clean checkout of `main` and is unrelated to this change.

---

Disclosure: I used an AI assistant while investigating and preparing this patch. I reproduced the crash, verified the fix and ran the test suite myself, and I take responsibility for the contents.
---
Disclosure: this change was prepared with AI assistance (Claude Code). The repro and tests described above were run before it was opened.
