### PR TITLE
Handle None config values for course

### DIFF
--- a/inginious/common/exceptions.py
+++ b/inginious/common/exceptions.py
@@ -25,7 +25,14 @@ class TaskNotFoundException(Exception):
 
 
 class CourseUnreadableException(Exception):
-    pass
+    """ Raised when a course's descriptor is not readable (e.g. invalid YAML) '"""
+
+    def __init__(self, message=None):
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self):
+        return self.message if self.message else "Course descriptor is not readable"
 
 
 class CourseAlreadyExistsException(Exception):

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -23,6 +23,7 @@ from inginious.frontend.user_manager import UserInfo
 from inginious.frontend.task_dispensers.toc import TableOfContents
 from inginious.frontend.plugins import plugin_manager
 from inginious.frontend.task_dispensers import get_task_dispensers
+from inginious.frontend.task_dispensers.util import InvalidTocException
 from inginious.frontend.tasks import Task
 from inginious.common.exceptions import InvalidNameException, CourseNotFoundException, CourseUnreadableException
 
@@ -79,12 +80,35 @@ class Course(object):
             self._lti_config = self._content.get('lti_config', {})
             self._lti_secrets = self._content.get('lti_secrets', {})
             self._lti_send_back_grade = self._content.get('lti_send_back_grade', False)
-            self._tags = {key: Tag(key, tag_dict, self.gettext) for key, tag_dict in self._content.get("tags", {}).items()}
+
+            tags = self._content.get("tags", {})
+            if not isinstance(tags, dict):
+                raise CourseUnreadableException("Course " + self.get_id() + " has an invalid tags structure " + str(tags))
+            self._tags = {key: Tag(key, tag_dict, self.gettext) for key, tag_dict in tags.items()}
+
             task_dispenser_class = get_task_dispensers().get(self._content.get('task_dispenser', 'toc'), TableOfContents)
             # Here we use a lambda to ensure we do not pass a fixed list of tasks to the task dispenser
             self._task_dispenser = task_dispenser_class(lambda: self.get_tasks(), self._content.get("dispenser_data", {}), self.get_id())
+
+        except InvalidTocException as e:
+            raise CourseUnreadableException("Course " + self.get_id() + " has an invalid dispenser data: " + str(e))
         except:
-            raise Exception("Course has an invalid YAML spec: " + self.get_id())
+            raise CourseUnreadableException("Course " + self.get_id() + " has an invalid YAML spec")
+
+        # checking types
+        list_fields = {"admins": self._admins, "tutors": self._tutors, "registration_ac_list": self._registration_ac_list}
+        bad_name = next((name for name, value in list_fields.items() if not isinstance(value, list)), None)
+        if bad_name is not None:
+            raise CourseUnreadableException(
+                f"Course {self.get_id()} has an invalid dispenser data: {bad_name} is not a list"
+            )
+
+        dict_fields = {"lti_keys": self._lti_keys, "lti_secrets": self._lti_secrets, "lti_config": self._lti_config}
+        bad_name = next((name for name, value in dict_fields.items() if not isinstance(value, dict)), None)
+        if bad_name is not None:
+            raise CourseUnreadableException(
+                f"Course {self.get_id()} has an invalid dispenser data: {bad_name} is not a dict"
+            )
 
         # Force some parameters if LTI is active
         if self.is_lti():

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import NotFound
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 from inginious.frontend.models import UserTask
+from werkzeug.exceptions import InternalServerError
 
 
 def handle_course_unavailable(user_manager, course):
@@ -34,8 +35,8 @@ class CoursePage(INGIniousAuthPage):
         """ Return the course """
         try:
             course = Course.get(courseid)
-        except:
-            raise NotFound(description=_("Course not found."))
+        except Exception as e:
+            raise InternalServerError(description=_(e))
 
         return course
 

--- a/inginious/frontend/task_dispensers/util.py
+++ b/inginious/frontend/task_dispensers/util.py
@@ -360,11 +360,11 @@ def parse_tasks_config(task_list, config_items, data):
 
     # Check each config validity
     for taskid, structure in data.items():
-        try:
-            for config_item in config_items:
+        for config_item in config_items:
+            try:
                 config_item.get_value(structure)
-        except Exception as ex:
-            raise InvalidTocException("In taskid {} : {}".format(taskid, str(ex)))
+            except Exception as ex:
+                raise InvalidTocException("In taskid {}, {} : {}".format(taskid, config_item.get_id(), str(ex)))
 
 
 def check_task_config(task_list, config_items, data):


### PR DESCRIPTION
This PR addresses #1104 

It adds a check on list and dict format to be sure they are never None. An error is raised in the UI informing the user which course and config element is at fault in the `course.yaml`. 
An error is also raised if the task config is erroneous, informing  which task config in `course.yaml` is responsible. 