### PR TITLE
Pydantic course config

### DIFF
--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -43,8 +43,6 @@ def _load_course(course_fs : FileSystemProvider, courseid : str):
 class CourseDescriptor(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True) # to allow AccessibleTime() objects in the model
 
-    # TODO : use strict validation ? -> no automatic strict conversion of types, we will need the archive_date validator
-
     name: str
     admins: list[str] = []
     tutors: list[str] = []
@@ -109,7 +107,7 @@ class CourseDescriptor(BaseModel):
             self.accessible = AccessibleTime(self.accessible)
             self.registration = AccessibleTime(self.registration)
         except Exception as e:
-            raise ValueError(f"Invalid accessible or registration time format: {e}")
+            raise ValueError(f"Invalid time format for 'accessible' or 'registration': {e}")
         return self
 
 
@@ -118,10 +116,11 @@ class Course(object):
 
     def __init__(self, courseid, content):
         self._id = courseid
+        self._pre_validated_content = content
         try:
             self._content = CourseDescriptor(**content)
         except ValidationError as e:
-            raise Exception(f"Course has an invalid YAML spec: {courseid}. Validation error: {e}")
+            raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]["loc"][0]}' YAML spec: {e.errors()[0]["msg"]}")
 
         self._fs = get_fs_provider().from_subfolder(courseid)
         self._new_doc = not self._fs.exists()
@@ -160,7 +159,7 @@ class Course(object):
             # Here we use a lambda to ensure we do not pass a fixed list of tasks to the task dispenser
             self._task_dispenser = task_dispenser_class(lambda: self.get_tasks(), self._content.dispenser_data, self.get_id())
         except Exception as e:
-            raise Exception("Course has an invalid task dispenser: " + self.get_id() + ". Error: " + str(e))
+            raise CourseUnreadableException(f"Course {self.get_id()} has an invalid task dispenser : {str(e)}")
 
         # Build the regex for the ACL, allowing for fast matching. Only used internally.
         self._registration_ac_regex = self._build_ac_regex(self._registration_ac_list)
@@ -187,9 +186,8 @@ class Course(object):
         return Task.get(self._id, taskid)
 
     def get_descriptor(self):
-        """ Get (a copy) the description of the course """ # change comment to say that it returns a dict instead of a copy of the CourseDescriptor object
-        #return copy.deepcopy(self._content)
-        return self._content.model_dump(exclude_none=False) # python mode to accept non-json-serializables (AccessibleTime, ...)
+        """ Get the description of the course as a python dict. """
+        return self._pre_validated_content # -> is this an alternative ? Needed ?
 
 
     def get_staff(self):
@@ -349,12 +347,11 @@ class Course(object):
         return self._archive_date
 
     def set_descriptor_element(self, key: str, value: Any):
-        self._content[key] = value
+        self._pre_validated_content[key] = value
 
     def save(self):
         """ Saves the Course into the filesystem """
-        #self._fs.put("course.yaml", get_json_or_yaml("course.yaml", self._content))
-        self._fs.put("course.yaml", get_json_or_yaml("course.yaml",  self._content.model_dump()))
+        self._fs.put("course.yaml", get_json_or_yaml("course.yaml", self._pre_validated_content))
         if self._new_doc:
             logging.getLogger("inginious.course").info("Course %s created in the factory.", self._fs.prefix)
 

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -47,7 +47,7 @@ class CourseDescriptor(BaseModel):
     admins: list[str] = []
     tutors: list[str] = []
     description: str = ""
-    accessible: Optional[str | bool | AccessibleTime] = None # TODO : avoid AccessibleTime instance in the descriptor ?
+    accessible: Optional[str | bool | AccessibleTime] = None
     registration: Optional[str | bool | AccessibleTime] = None
     registration_password: Optional[str] = None
     registration_ac: Optional[Literal["username", "binding", "email"]] = None
@@ -100,15 +100,22 @@ class CourseDescriptor(BaseModel):
             )
         return task_dispenser
 
-    # check AccessibleTime() format
-    @model_validator(mode="after")
-    def verify_accessible_time(self):
+    # check given accessible and registration values are valid
+    @field_validator("accessible", mode="after")
+    @classmethod
+    def verify_accessible(cls, v):
         try:
-            self.accessible = AccessibleTime(self.accessible)
-            self.registration = AccessibleTime(self.registration)
+            return AccessibleTime(v)
         except Exception as e:
-            raise ValueError(f"Invalid time format for 'accessible' or 'registration': {e}")
-        return self
+            raise ValueError(f"Invalid time format.")
+
+    @field_validator("registration", mode="after")
+    @classmethod
+    def verify_registration(cls, v):
+        try:
+            return AccessibleTime(v)
+        except Exception as e:
+            raise ValueError(f"Invalid time format.")
 
 
 class Course(object):
@@ -132,26 +139,6 @@ class Course(object):
         if self._content.nofrontend:
             raise Exception("That course is not allowed to be displayed directly in the webapp")
 
-        self._admins = self._content.admins
-        self._tutors = self._content.tutors
-        self._description = self._content.description
-        self._accessible = self._content.accessible
-        self._registration = self._content.registration
-        self._registration_password = self._content.registration_password
-        self._registration_ac = self._content.registration_ac
-        self._registration_ac_accept = self._content.registration_ac_accept
-        self._registration_ac_list = self._content.registration_ac_list
-        self._groups_student_choice = self._content.groups_student_choice
-        self._allow_unregister = self._content.allow_unregister
-        self._allow_preview = self._content.allow_preview
-        self._is_lti = self._content.is_lti
-        self._is_archive = self._content.archived
-        self._archive_date = self._content.archive_date
-        self._lti_url = self._content.lti_url
-        self._lti_keys = self._content.lti_keys
-        self._lti_config = self._content.lti_config
-        self._lti_secrets = self._content.lti_secrets
-        self._lti_send_back_grade = self._content.lti_send_back_grade
         self._tags = {key: Tag(key, tag_dict, self.gettext) for key, tag_dict in self._content.tags.items()}
 
         try:
@@ -162,7 +149,7 @@ class Course(object):
             raise CourseUnreadableException(f"Course {self.get_id()} has an invalid task dispenser : {str(e)}")
 
         # Build the regex for the ACL, allowing for fast matching. Only used internally.
-        self._registration_ac_regex = self._build_ac_regex(self._registration_ac_list)
+        self._registration_ac_regex = self._build_ac_regex(self._content.registration_ac_list)
 
     def set_translations(self, translations : dict[str, gettext.GNUTranslations]):
         self._translations = translations
@@ -187,7 +174,7 @@ class Course(object):
 
     def get_descriptor(self):
         """ Get the description of the course as a python dict. """
-        return self._pre_validated_content # -> is this an alternative ? Needed ?
+        return copy.deepcopy(self._pre_validated_content)
 
 
     def get_staff(self):
@@ -196,11 +183,11 @@ class Course(object):
 
     def get_admins(self):
         """ Returns a list containing the usernames of the administrators of this course """
-        return self._admins
+        return self._content.admins
 
     def get_tutors(self):
         """ Returns a list containing the usernames of the tutors assigned to this course """
-        return self._tutors
+        return self._content.tutors
 
     def is_open_to_non_staff(self):
         """ Returns true if the course is accessible by users that are not administrator of this course """
@@ -208,27 +195,27 @@ class Course(object):
 
     def is_registration_possible(self, user_info: UserInfo):
         """ Returns true if users can register for this course """
-        return self.get_accessibility().is_open() and self._registration.is_open() and self.is_user_accepted_by_access_control(user_info)
+        return self.get_accessibility().is_open() and self._content.registration.is_open() and self.is_user_accepted_by_access_control(user_info)
 
     def is_password_needed_for_registration(self):
         """ Returns true if a password is needed for registration """
-        return self._registration_password is not None
+        return self._content.registration_password is not None
 
     def get_registration_password(self):
         """ Returns the password needed for registration (None if there is no password) """
-        return self._registration_password
+        return self._content.registration_password
 
     def get_accessibility(self, plugin_override=True):
         """ Return the AccessibleTime object associated with the accessibility of this course """
         if self.is_archive():
             return AccessibleTime(False)
 
-        vals = plugin_manager.call_hook('course_accessibility', course=self, default=self._accessible)
-        return vals[0] if len(vals) and plugin_override else self._accessible
+        vals = plugin_manager.call_hook('course_accessibility', course=self, default=self._content.accessible)
+        return vals[0] if len(vals) and plugin_override else self._content.accessible
 
     def get_registration_accessibility(self):
         """ Return the AccessibleTime object associated with the registration """
-        return self._registration
+        return self._content.registration
 
     def get_readable_tasks(self):
         """ Returns the list of all available tasks in a course """
@@ -251,43 +238,43 @@ class Course(object):
 
     def get_access_control_method(self):
         """ Returns either None, "username", "binding", or "email", depending on the method used to verify that users can register to the course """
-        return self._registration_ac
+        return self._content.registration_ac
 
     def get_access_control_accept(self):
         """ Returns either True (accept) or False (deny), depending on the control type used to verify that users can register to the course """
-        return self._registration_ac_accept
+        return self._content.registration_ac_accept
 
     def get_access_control_list(self) -> List[str]:
         """ Returns the list of all users/emails/binding methods/... (see get_access_control_method) allowed by the AC list """
-        return self._registration_ac_list
+        return self._content.registration_ac_list
 
     def can_students_choose_group(self):
         """ Returns True if the students can choose their groups """
-        return self._groups_student_choice
+        return self._content.groups_student_choice
 
     def is_lti(self):
         """ True if the current course is in LTI mode """
-        return self._is_lti
+        return self._content.is_lti
 
     def lti_keys(self):
         """ {name: key} for the LTI customers """
-        return self._lti_keys if self._is_lti else {}
+        return self._content.lti_keys if self._content.is_lti else {}
 
     def lti_config(self):
         """ LTI Tool config dictionary. Specs are at https://github.com/dmitry-viskov/pylti1.3/blob/master/README.rst?plain=1#L70-L98 """
-        return self._lti_config if self._is_lti else {}
+        return self._content.lti_config if self._content.is_lti else {}
 
     def lti_secrets(self):
         """ {deployment: secret} for the LTI 1.3 consumers """
-        return self._lti_secrets if self._is_lti else {}
+        return self._content.lti_secrets if self._content.is_lti else {}
 
     def lti_url(self):
         """ Returns the URL to the external platform the course is hosted on """
-        return self._lti_url
+        return self._content.lti_url
 
     def lti_send_back_grade(self):
         """ True if the current course should send back grade to the LTI Tool Consumer """
-        return self._is_lti and self._lti_send_back_grade
+        return self._content.is_lti and self._content.lti_send_back_grade
 
     def is_user_accepted_by_access_control(self, user_info: UserInfo):
         """ Returns True if the user is allowed by the ACL """
@@ -309,12 +296,12 @@ class Course(object):
         return at_least_one if self.get_access_control_accept() else not at_least_one
 
     def allow_preview(self):
-        return self._allow_preview
+        return self._content.allow_preview
 
     def allow_unregister(self, plugin_override=True):
         """ Returns True if students can unregister from course """
-        vals = plugin_manager.call_hook('course_allow_unregister', course=self, default=self._allow_unregister)
-        return vals[0] if len(vals) and plugin_override else self._allow_unregister
+        vals = plugin_manager.call_hook('course_allow_unregister', course=self, default=self._content.allow_unregister)
+        return vals[0] if len(vals) and plugin_override else self._content.allow_unregister
 
     def get_name(self, language):
         """ Return the name of this course """
@@ -322,7 +309,7 @@ class Course(object):
 
     def get_description(self, language):
         """Returns the course description """
-        description = self.gettext(language, self._description) if self._description else ''
+        description = self.gettext(language, self._content.description) if self._content.description else ''
         return ParsableText(description, "rst")
 
     def get_tags(self):
@@ -340,11 +327,11 @@ class Course(object):
 
     def is_archive(self):
         """ Returns true if the course is an archive"""
-        return self._is_archive
+        return self._content.archived
 
     def get_archiving_date(self):
         """ Returns the date at which the course was archived as a string (None if not archived)"""
-        return self._archive_date
+        return self._content.archive_date
 
     def set_descriptor_element(self, key: str, value: Any):
         self._pre_validated_content[key] = value

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -127,7 +127,7 @@ class Course(object):
         try:
             self._content = CourseDescriptor(**content)
         except ValidationError as e:
-            raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]["loc"][0]}' YAML spec: {e.errors()[0]["msg"]}")
+            raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]['loc'][0]}' YAML spec: {e.errors()[0]['msg']}")
 
         self._fs = get_fs_provider().from_subfolder(courseid)
         self._new_doc = not self._fs.exists()

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -11,8 +11,10 @@ import gettext
 import re
 import os
 import logging
-from typing import Iterable, List, Any
+from typing import List, Any
 from datetime import datetime
+from pydantic import BaseModel, Field, field_validator, model_validator, ValidationError, ConfigDict
+from typing import Optional, Literal
 
 from inginious.common.filesystems import FileSystemProvider, fetch_or_cache, invalidate_cache, get_fs_provider
 from inginious.common.tags import Tag
@@ -37,70 +39,128 @@ def _load_course(course_fs : FileSystemProvider, courseid : str):
 
     return Course(courseid, task_content)
 
+
+class CourseDescriptor(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True) # to allow AccessibleTime() objects in the model
+
+    # TODO : use strict validation ? -> no automatic strict conversion of types, we will need the archive_date validator
+
+    name: str
+    admins: list[str] = []
+    tutors: list[str] = []
+    description: str = ""
+    accessible: Optional[str | bool | AccessibleTime] = None # TODO : avoid AccessibleTime instance in the descriptor ?
+    registration: Optional[str | bool | AccessibleTime] = None
+    registration_password: Optional[str] = None
+    registration_ac: Optional[Literal["username", "binding", "email"]] = None
+    registration_ac_accept: bool = True
+    registration_ac_list: list[str] = []
+    groups_student_choice: bool = False
+    allow_unregister: bool = True
+    allow_preview: bool = False
+    is_lti: bool = False
+    archived: bool = False
+    archive_date: Optional[datetime] = Field( # using datetime type to allow automatic parsing of ISO-8601 strings + accept parsed value by validator
+        default=None,
+        description="ISO-8601 date/time string",
+    )
+    lti_url: str = ""
+    lti_keys: dict = {}
+    lti_config: dict = {}
+    lti_secrets: dict = {}
+    lti_send_back_grade: bool = False
+    tags: dict = {}
+    task_dispenser: str = "toc"
+    dispenser_data: dict = {}
+    nofrontend: bool = False
+
+    # Force some parameters if LTI is active
+    @model_validator(mode="after")
+    def apply_lti_overrides(self):
+        if self.is_lti:
+            self.accessible = True
+            self.registration = False
+            self.registration_password = None
+            self.registration_ac = None
+            self.registration_ac_list = []
+            self.groups_student_choice = False
+            self.allow_unregister = False
+        else:
+            self.lti_keys, self.lti_secrets, self.lti_config = {}, {}, {}
+            self.lti_url = ""
+            self.lti_send_back_grade = False
+        return self
+
+    # check task dispenser is valid
+    @field_validator("task_dispenser", mode="after")
+    @classmethod
+    def check_task_dispenser_registered(cls, task_dispenser: str) -> str:
+        available_task_dispensers = get_task_dispensers()
+        if task_dispenser not in available_task_dispensers:
+            raise ValueError(
+                f"Unknown task dispenser '{task_dispenser}'. Registered dispensers: {sorted(available_task_dispensers.keys())}"
+            )
+        return task_dispenser
+
+    # check AccessibleTime() format
+    @model_validator(mode="after")
+    def verify_accessible_time(self):
+        try:
+            self.accessible = AccessibleTime(self.accessible)
+            self.registration = AccessibleTime(self.registration)
+        except Exception as e:
+            raise ValueError(f"Invalid accessible or registration time format: {e}")
+        return self
+
+
 class Course(object):
     """ A course with some modification for users """
 
     def __init__(self, courseid, content):
         self._id = courseid
-        self._content = content
+        try:
+            self._content = CourseDescriptor(**content)
+        except ValidationError as e:
+            raise Exception(f"Course has an invalid YAML spec: {courseid}. Validation error: {e}")
+
         self._fs = get_fs_provider().from_subfolder(courseid)
         self._new_doc = not self._fs.exists()
 
         self._translations = {}
 
-        try:
-            self._name = self._content['name']
-        except:
-            raise Exception("Course has an invalid name: " + self.get_id())
+        self._name = self._content.name
 
-        if self._content.get('nofrontend', False):
+        if self._content.nofrontend:
             raise Exception("That course is not allowed to be displayed directly in the webapp")
 
-        try:
-            self._admins = self._content.get('admins', [])
-            self._tutors = self._content.get('tutors', [])
-            self._description = self._content.get('description', '')
-            self._accessible = AccessibleTime(self._content.get("accessible", None))
-            self._registration = AccessibleTime(self._content.get("registration", None))
-            self._registration_password = self._content.get('registration_password', None)
-            self._registration_ac = self._content.get('registration_ac', None)
-            if self._registration_ac not in [None, "username", "binding", "email"]:
-                raise Exception("Course has an invalid value for registration_ac: " + self.get_id())
-            self._registration_ac_accept = self._content.get('registration_ac_accept', True)
-            self._registration_ac_list = self._content.get('registration_ac_list', [])
-            self._groups_student_choice = self._content.get("groups_student_choice", False)
-            self._allow_unregister = self._content.get('allow_unregister', True)
-            self._allow_preview = self._content.get('allow_preview', False)
-            self._is_lti = self._content.get('is_lti', False)
-            self._is_archive = self._content.get('archived', False)
-            self._archive_date = datetime.fromisoformat(self._content["archive_date"]).astimezone() if "archive_date" in self._content else None
-            self._lti_url = self._content.get('lti_url', '')
-            self._lti_keys = self._content.get('lti_keys', {})
-            self._lti_config = self._content.get('lti_config', {})
-            self._lti_secrets = self._content.get('lti_secrets', {})
-            self._lti_send_back_grade = self._content.get('lti_send_back_grade', False)
-            self._tags = {key: Tag(key, tag_dict, self.gettext) for key, tag_dict in self._content.get("tags", {}).items()}
-            task_dispenser_class = get_task_dispensers().get(self._content.get('task_dispenser', 'toc'), TableOfContents)
-            # Here we use a lambda to ensure we do not pass a fixed list of tasks to the task dispenser
-            self._task_dispenser = task_dispenser_class(lambda: self.get_tasks(), self._content.get("dispenser_data", {}), self.get_id())
-        except:
-            raise Exception("Course has an invalid YAML spec: " + self.get_id())
+        self._admins = self._content.admins
+        self._tutors = self._content.tutors
+        self._description = self._content.description
+        self._accessible = self._content.accessible
+        self._registration = self._content.registration
+        self._registration_password = self._content.registration_password
+        self._registration_ac = self._content.registration_ac
+        self._registration_ac_accept = self._content.registration_ac_accept
+        self._registration_ac_list = self._content.registration_ac_list
+        self._groups_student_choice = self._content.groups_student_choice
+        self._allow_unregister = self._content.allow_unregister
+        self._allow_preview = self._content.allow_preview
+        self._is_lti = self._content.is_lti
+        self._is_archive = self._content.archived
+        self._archive_date = self._content.archive_date
+        self._lti_url = self._content.lti_url
+        self._lti_keys = self._content.lti_keys
+        self._lti_config = self._content.lti_config
+        self._lti_secrets = self._content.lti_secrets
+        self._lti_send_back_grade = self._content.lti_send_back_grade
+        self._tags = {key: Tag(key, tag_dict, self.gettext) for key, tag_dict in self._content.tags.items()}
 
-        # Force some parameters if LTI is active
-        if self.is_lti():
-            self._accessible = AccessibleTime(True)
-            self._registration = AccessibleTime(False)
-            self._registration_password = None
-            self._registration_ac = None
-            self._registration_ac_list = []
-            self._groups_student_choice = False
-            self._allow_unregister = False
-        else:
-            self._lti_keys = {}
-            self._lti_secrets = {}
-            self._lti_config = {}
-            self._lti_url = ''
-            self._lti_send_back_grade = False
+        try:
+            task_dispenser_class = get_task_dispensers().get(self._content.task_dispenser, TableOfContents)
+            # Here we use a lambda to ensure we do not pass a fixed list of tasks to the task dispenser
+            self._task_dispenser = task_dispenser_class(lambda: self.get_tasks(), self._content.dispenser_data, self.get_id())
+        except Exception as e:
+            raise Exception("Course has an invalid task dispenser: " + self.get_id() + ". Error: " + str(e))
 
         # Build the regex for the ACL, allowing for fast matching. Only used internally.
         self._registration_ac_regex = self._build_ac_regex(self._registration_ac_list)
@@ -127,8 +187,10 @@ class Course(object):
         return Task.get(self._id, taskid)
 
     def get_descriptor(self):
-        """ Get (a copy) the description of the course """
-        return copy.deepcopy(self._content)
+        """ Get (a copy) the description of the course """ # change comment to say that it returns a dict instead of a copy of the CourseDescriptor object
+        #return copy.deepcopy(self._content)
+        return self._content.model_dump(exclude_none=False) # python mode to accept non-json-serializables (AccessibleTime, ...)
+
 
     def get_staff(self):
         """ Returns a list containing the usernames of all the staff users """
@@ -291,7 +353,8 @@ class Course(object):
 
     def save(self):
         """ Saves the Course into the filesystem """
-        self._fs.put("course.yaml", get_json_or_yaml("course.yaml", self._content))
+        #self._fs.put("course.yaml", get_json_or_yaml("course.yaml", self._content))
+        self._fs.put("course.yaml", get_json_or_yaml("course.yaml",  self._content.model_dump()))
         if self._new_doc:
             logging.getLogger("inginious.course").info("Course %s created in the factory.", self._fs.prefix)
 

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -14,6 +14,7 @@ import logging
 from typing import List, Any
 from datetime import datetime
 from pydantic import BaseModel, Field, field_validator, model_validator, ValidationError, ConfigDict
+from pydantic_core import InitErrorDetails
 from typing import Optional, Literal
 
 from inginious.common.filesystems import FileSystemProvider, fetch_or_cache, invalidate_cache, get_fs_provider
@@ -116,6 +117,35 @@ class CourseDescriptor(BaseModel):
             return AccessibleTime(v)
         except Exception as e:
             raise ValueError(f"Invalid time format.")
+
+    # validator on archived VS archive_date
+    @model_validator(mode="after")
+    def check_archive_fields(self):
+        if self.archived and not self.archive_date:
+            raise ValidationError.from_exception_data(
+                self.__class__.__name__,
+                [
+                    InitErrorDetails(
+                        type="value_error",
+                        loc=("archive_date",),
+                        input=self.archive_date,
+                        ctx={"error": ValueError("Archive_date must be set if archived is True.")},
+                    )
+                ],
+            )
+        if not self.archived and self.archive_date:
+            raise ValidationError.from_exception_data(
+                self.__class__.__name__,
+                [
+                    InitErrorDetails(
+                        type="value_error",
+                        loc=("archived",),
+                        input=self.archived,
+                        ctx={"error": ValueError("Archive_date is given but archived is False.")},
+                    )
+                ],
+            )
+        return self
 
 
 class Course(object):

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -127,7 +127,10 @@ class Course(object):
         try:
             self._content = CourseDescriptor(**content)
         except ValidationError as e:
-            raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]['loc'][0]}' YAML spec: {e.errors()[0]['msg']}")
+            if bool(set(e.errors()[0]['loc']) & {"admins", "tutors", "registration_password", "registration_ac_list", "lti_secrets", }):  # if the error is related to a sensitive field, do not print the message
+                raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]['loc'][0]}' YAML spec.")
+            else:
+                raise CourseUnreadableException(f"Course '{courseid}' has an invalid '{e.errors()[0]['loc'][0]}' YAML spec: {e.errors()[0]['msg']}")
 
         self._fs = get_fs_provider().from_subfolder(courseid)
         self._new_doc = not self._fs.exists()

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -8,6 +8,7 @@ import flask
 from flask import session, redirect, render_template, url_for
 from werkzeug.exceptions import NotFound
 
+from inginious.common.exceptions import CourseUnreadableException
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 from inginious.frontend.models import UserTask
@@ -34,8 +35,8 @@ class CoursePage(INGIniousAuthPage):
         """ Return the course """
         try:
             course = Course.get(courseid)
-        except:
-            raise NotFound(description=_("Course not found."))
+        except ValueError as e:
+            raise CourseUnreadableException(str(e))
 
         return course
 

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -40,7 +40,7 @@ class CoursePage(INGIniousAuthPage):
             course = Course.get(courseid)
         except CourseUnreadableException as e:
             self._logger.error(str(e))
-            raise NotFound(description=_("Course not found."))
+            raise NotFound(description=str(e))
         except InvalidNameException as e:
             self._logger.error(str(e))
             raise NotFound(description=_("Course not found."))

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -8,7 +8,7 @@ import flask
 from flask import session, redirect, render_template, url_for
 from werkzeug.exceptions import NotFound
 
-from inginious.common.exceptions import CourseUnreadableException
+from inginious.common.exceptions import CourseUnreadableException, InvalidNameException, CourseNotFoundException
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 from inginious.frontend.models import UserTask
@@ -35,8 +35,14 @@ class CoursePage(INGIniousAuthPage):
         """ Return the course """
         try:
             course = Course.get(courseid)
-        except ValueError as e:
-            raise CourseUnreadableException(str(e))
+        except CourseUnreadableException as e:
+            raise NotFound(description=str(e))
+        except InvalidNameException as e:
+            raise NotFound(description=str(e))
+        except CourseNotFoundException:
+            raise NotFound(description=_("Course not found."))
+        except:
+            raise NotFound(description=_("An error occurred while loading the course."))
 
         return course
 

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -7,6 +7,7 @@
 import flask
 from flask import session, redirect, render_template, url_for
 from werkzeug.exceptions import NotFound
+import logging
 
 from inginious.common.exceptions import CourseUnreadableException, InvalidNameException, CourseNotFoundException
 from inginious.frontend.courses import Course
@@ -27,6 +28,8 @@ def handle_course_unavailable(user_manager, course):
 class CoursePage(INGIniousAuthPage):
     """ Course page """
 
+    _logger = logging.getLogger("inginious.frontend.course")
+
     def preview_allowed(self, courseid):
         course = self.get_course(courseid)
         return course.get_accessibility().is_open() and course.allow_preview()
@@ -36,13 +39,17 @@ class CoursePage(INGIniousAuthPage):
         try:
             course = Course.get(courseid)
         except CourseUnreadableException as e:
-            raise NotFound(description=str(e))
-        except InvalidNameException as e:
-            raise NotFound(description=str(e))
-        except CourseNotFoundException:
+            self._logger.error(str(e))
             raise NotFound(description=_("Course not found."))
-        except:
-            raise NotFound(description=_("An error occurred while loading the course."))
+        except InvalidNameException as e:
+            self._logger.error(str(e))
+            raise NotFound(description=_("Course not found."))
+        except CourseNotFoundException:
+            self._logger.error(f"Course {courseid} not found.")
+            raise NotFound(description=_("Course not found."))
+        except Exception as e:
+            self._logger.error(f"Error while fetching course {courseid}: {str(e)}")
+            raise NotFound(description=_("Course not found."))
 
         return course
 

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -54,7 +54,7 @@ class INGIniousAdminPage(INGIniousAuthPage):
                 return course, course.get_task(taskid)
         except CourseUnreadableException as e:
             self._logger.error(str(e))
-            raise NotFound(description=_("Course not found."))
+            raise NotFound(description=str(e))
         except InvalidNameException as e:
             self._logger.error(str(e))
             raise NotFound(description=_("Course not found."))

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -10,6 +10,7 @@ import csv
 import io
 from collections import OrderedDict
 from datetime import datetime
+import logging
 
 from flask import  session, redirect, Response, url_for
 from werkzeug.exceptions import Forbidden, NotFound
@@ -26,6 +27,8 @@ class INGIniousAdminPage(INGIniousAuthPage):
     """
     An improved version of INGIniousAuthPage that checks rights for the administration
     """
+
+    _logger = logging.getLogger("inginious.frontend.course_admin")
 
     def get_course_and_check_rights(self, courseid, taskid=None, allow_all_staff=True):
         """ Returns the course with id ``courseid`` and the task with id ``taskid``, and verify the rights of the user.
@@ -50,13 +53,17 @@ class INGIniousAdminPage(INGIniousAuthPage):
             else:
                 return course, course.get_task(taskid)
         except CourseUnreadableException as e:
-            raise NotFound(description=str(e))
-        except InvalidNameException as e:
-            raise NotFound(description=str(e))
-        except CourseNotFoundException:
+            self._logger.error(str(e))
             raise NotFound(description=_("Course not found."))
-        except:
-            raise NotFound(description=_("An error occurred while loading the course."))
+        except InvalidNameException as e:
+            self._logger.error(str(e))
+            raise NotFound(description=_("Course not found."))
+        except CourseNotFoundException:
+            self._logger.error(f"Course {courseid} not found.")
+            raise NotFound(description=_("Course not found."))
+        except Exception as e:
+            self._logger.error(f"Error while fetching course {courseid}: {str(e)}")
+            raise NotFound(description=_("Course not found."))
 
 
 class INGIniousSubmissionsAdminPage(INGIniousAdminPage):

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -12,10 +12,11 @@ from collections import OrderedDict
 from datetime import datetime
 
 from flask import  session, redirect, Response, url_for
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, NotFound
 from bson.objectid import ObjectId
 
 from inginious.common.base import id_checker
+from inginious.common.exceptions import CourseUnreadableException
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 from inginious.frontend.models import UserTask, Audience
@@ -48,7 +49,9 @@ class INGIniousAdminPage(INGIniousAuthPage):
                 return course, None
             else:
                 return course, course.get_task(taskid)
-        except:
+        except CourseUnreadableException as e:
+            raise NotFound(description=_(e))
+        except Exception as e:
             raise Forbidden(description=_("This course is unreachable"))
 
 

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import Forbidden, NotFound
 from bson.objectid import ObjectId
 
 from inginious.common.base import id_checker
-from inginious.common.exceptions import CourseUnreadableException
+from inginious.common.exceptions import CourseUnreadableException, InvalidNameException, CourseNotFoundException
 from inginious.frontend.courses import Course
 from inginious.frontend.pages.utils import INGIniousAuthPage
 from inginious.frontend.models import UserTask, Audience
@@ -50,9 +50,13 @@ class INGIniousAdminPage(INGIniousAuthPage):
             else:
                 return course, course.get_task(taskid)
         except CourseUnreadableException as e:
-            raise NotFound(description=_(e))
-        except Exception as e:
-            raise Forbidden(description=_("This course is unreachable"))
+            raise NotFound(description=str(e))
+        except InvalidNameException as e:
+            raise NotFound(description=str(e))
+        except CourseNotFoundException:
+            raise NotFound(description=_("Course not found."))
+        except:
+            raise NotFound(description=_("An error occurred while loading the course."))
 
 
 class INGIniousSubmissionsAdminPage(INGIniousAdminPage):

--- a/inginious/frontend/templates/course.html
+++ b/inginious/frontend/templates/course.html
@@ -118,7 +118,7 @@
     {% endif %}
 </div>
 
-{% if course.get_descriptor().get("description", "") %}
+{% if course.get_descriptor().description %}
     <div class="mb-3" id="desc_accord" role="tablist" aria-multiselectable="true">
         <div class="card">
             <div class="card-header" id="course_desc_head">

--- a/inginious/frontend/templates/course_admin/settings.html
+++ b/inginious/frontend/templates/course_admin/settings.html
@@ -83,7 +83,7 @@
             <div class="form-group row">
                 <label for="description" class="col-sm-2 control-label">{{ _("Description") }} </label>
                 <div class="col-sm-10">
-                    <textarea id="description" class="code-editor form-control" name="description" data-x-language="rst" data-x-lines="10">{{ course.get_descriptor().get('description','') }}</textarea>
+                    <textarea id="description" class="code-editor form-control" name="description" data-x-language="rst" data-x-lines="10">{{ course.get_descriptor().description }}</textarea>
                 </div>
             </div>
             <div class="form-group row">
@@ -458,7 +458,7 @@
                     </td>
                 </tr>
 
-                {% for key, tag in course.get_descriptor().get("tags", {}).items() %}
+                {% for key, tag in course.get_descriptor().tags.items() %}
                     {% set name = tag["name"] if "name" in tag else _("Unknown name") %}
                     {% set description = tag["description"] if "description" in tag else "" %}
                     {% set type = tag["type"] if "type" in tag else 0 %}

--- a/inginious/frontend/tests/tasks/test4/course.yaml
+++ b/inginious/frontend/tests/tasks/test4/course.yaml
@@ -1,0 +1,1 @@
+name: 'Unit test 4'

--- a/inginious/frontend/tests/test_course.py
+++ b/inginious/frontend/tests/test_course.py
@@ -9,6 +9,7 @@ import pytest
 import os
 import tempfile
 import shutil
+import datetime
 
 from inginious.common.filesystems import init_fs_provider
 from inginious.common.filesystems.local import LocalFSProvider
@@ -19,6 +20,7 @@ from inginious.common.tasks_problems import register_problem_types
 from inginious.frontend.task_problems import get_default_displayable_problem_types
 from inginious.frontend.task_dispensers import register_task_dispenser
 from inginious.frontend.task_dispensers.combinatory_test import CombinatoryTest
+from inginious.frontend.accessible_time import AccessibleTime
 
 task_dispensers = {TableOfContents.get_id(): TableOfContents, CombinatoryTest.get_id(): CombinatoryTest}
 
@@ -48,21 +50,205 @@ class TestCourse(object):
         print("\033[1m-> common-courses: course loading\033[0m")
         c = Course.get('test')
         assert c.get_id() == 'test'
-        assert c._content['accessible'] == True
-        assert c._content['admins'] == ['testadmin1', 'testadmin2']
-        assert c._content['name'] == 'Unit test 1'
+        assert c._pre_validated_content['accessible'] == True
+        assert c._pre_validated_content['admins'] == ['testadmin1', 'testadmin2']
+        assert c._pre_validated_content['name'] == 'Unit test 1'
 
         c = Course.get('test2')
         assert c.get_id() == 'test2'
-        assert c._content['accessible'] == '1970-01-01/2033-01-01'
-        assert c._content['admins'] == ['testadmin1']
-        assert c._content['name'] == 'Unit test 2'
+        assert c._pre_validated_content['accessible'] == '1970-01-01/2033-01-01'
+        assert c._pre_validated_content['admins'] == ['testadmin1']
+        assert c._pre_validated_content['name'] == 'Unit test 2'
 
         c = Course.get('test3')
         assert c.get_id() == 'test3'
-        assert c._content['accessible'] == '1970-01-01/1970-12-31'
-        assert c._content['admins'] == ['testadmin1', 'testadmin2']
-        assert c._content['name'] == 'Unit test 3'
+        assert c._pre_validated_content['accessible'] == '1970-01-01/1970-12-31'
+        assert c._pre_validated_content['admins'] == ['testadmin1', 'testadmin2']
+        assert c._pre_validated_content['name'] == 'Unit test 3'
+
+    def test_course_defaults(self, ressource):
+        """Tests if a course file loads correctly with default values from the """
+        print("\033[1m-> common-courses: course defaults\033[0m")
+        c = Course.get('test4')
+        assert c.get_id() == 'test4'
+        assert c._content.admins == []
+        assert c._content.tutors == []
+        assert c._content.description == ""
+        assert c._content.accessible is None
+        assert c._content.registration is None
+        assert c._content.registration_password is None
+        assert c._content.registration_ac is None
+        assert c._content.registration_ac_accept is True
+        assert c._content.registration_ac_list == []
+        assert c._content.groups_student_choice is False
+        assert c._content.allow_unregister is True
+        assert c._content.allow_preview is False
+        assert c._content.is_lti is False
+        assert c._content.archived is False
+        assert c._content.archive_date is None
+        assert c._content.lti_url == ""
+        assert c._content.lti_keys == {}
+        assert c._content.lti_config == {}
+        assert c._content.lti_secrets == {}
+        assert c._content.lti_send_back_grade is False
+        assert c._content.tags == {}
+        assert c._content.task_dispenser == "toc"
+        assert c._content.dispenser_data == {}
+        assert c._content.nofrontend is False
+
+    def test_course_missing_fields(self, ressource):
+        """Tests if a ValidationError is raised when a course file is missing required fields"""
+        print("\033[1m-> common-courses: course missing fields\033[0m")
+        try:
+            Course("test5", {"description": "Test course without name"}) # missing required fields
+        except:
+            return
+        assert False
+
+    def test_course_invalid_accessible_time(self, ressource):
+        """Tests validation on AccessibleTime fields (accessible and registration)"""
+        print("\033[1m-> common-courses: course invalid accessible/registration time\033[0m")
+        descriptor = {
+            "name": "Unit test 6",
+            "accessible": "/2026-08-24 16:52:33+02:00",
+            "registration": "/202-08-24 16:52:33+02:00", # invalid date
+        }
+        try:
+            Course("test6", descriptor)
+        except:
+            return
+
+        descriptor = {
+            "name": "Unit test 6",
+            "accessible": "Monday", # invalid date
+            "registration": False,
+        }
+        try:
+            Course("test6", descriptor)
+        except:
+            return
+        assert False
+
+    def test_course_valid_accessible_time(self, ressource):
+        """Tests validation on AccessibleTime fields (accessible and registration)"""
+        print("\033[1m-> common-courses: course invalid accessible/registration time\033[0m")
+        descriptor = {
+            "name": "Unit test 6",
+            "accessible": "/2026-08-24 16:52:33+02:00",
+            "registration": True,
+        }
+        try:
+            Course("test6", descriptor)
+        except:
+            assert False
+        assert True
+
+    def test_course_invalid_task_dispenser(self, ressource):
+        """Tests validation on task_dispenser field"""
+        print("\033[1m-> common-courses: course invalid task_dispenser\033[0m")
+        descriptor = {
+            "name": "Unit test 7",
+            "task_dispenser": "invalid_dispenser", # unavailable task dispenser
+        }
+        try:
+            Course("test7", descriptor)
+        except:
+            return
+        assert False
+
+    def test_course_valid_task_dispenser(self, ressource):
+        """Tests validation on task_dispenser field"""
+        print("\033[1m-> common-courses: course valid task_dispenser\033[0m")
+        descriptor = {
+            "name": "Unit test 8",
+            "task_dispenser": "combinatory_test", # available task dispenser
+        }
+        try:
+            Course("test8", descriptor)
+        except:
+            assert False
+        assert True
+
+    def test_course_lti_update(self, ressource):
+        """Tests if lti fields are updated correctly  """
+        print("\033[1m-> common-courses: course lti update\033[0m")
+        descriptor = {
+            "name": "Unit test 9",
+            "is_lti": True,
+        }
+        c = Course("test9", descriptor)
+        assert c._content.accessible == True
+        assert c._content.registration == False
+        assert c._content.registration_password is None
+        assert c._content.registration_ac is None
+        assert c._content.registration_ac_list == []
+        assert c._content.groups_student_choice == False
+        assert c._content.allow_unregister == False
+
+        descriptor = {
+            "name": "Unit test 9",
+            "is_lti": False,
+        }
+        c = Course("test9", descriptor)
+        assert c._content.lti_keys == {}
+        assert c._content.lti_secrets == {}
+        assert c._content.lti_config == {}
+        assert c._content.lti_url == ""
+        assert c._content.lti_send_back_grade == False
+
+    def test_course_archive_date_validation(self, ressource):
+        """Tests validation on archive_date field, """
+        print("\033[1m-> common-courses: course archive_date validation.\033[0m")
+        descriptor = {
+            "name": "Unit test 10",
+            "archived": True,
+            "archive_date": "2026-08-24 16:52:33+02:00", # valid date
+        }
+
+        c = Course("test10", descriptor)
+        assert c._content.archive_date == datetime.datetime(2026, 8, 24, 16, 52, 33, tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
+
+        descriptor = {
+            "name": "Unit test 11",
+            "archived": True,
+            "archive_date": "invalid-date", # invalid date
+        }
+
+        try:
+            Course("test11", descriptor)
+        except:
+            return
+        assert False
+
+    def test_course_archive_date_none(self,  ressource):
+        """Tests validation on archive_date field not present when archived. """
+        print("\033[1m-> common-courses: course archived/archive_date validation, archived with no date. \033[0m")
+        descriptor = {
+            "name": "Unit test 12",
+            "archived": True,
+            "archive_date": None, # valid date
+        }
+
+        try:
+            Course("test12", descriptor)
+        except:
+            return
+        assert False
+
+    def test_course_archive_date_not_archived(self,  ressource):
+        """Tests validation on archive_date field present when not archived. """
+        print("\033[1m-> common-courses: course archived/archive_date validation, not archived with date.\033[0m")
+        descriptor = {
+            "name": "Unit test 13",
+            "archived": False,
+            "archive_date": "2026-08-24 16:52:33+02:00", # valid date
+        }
+
+        try:
+            Course("test13", descriptor)
+        except:
+            return
+        assert False
 
     def test_invalid_coursename(self, ressource):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ dependencies = [
     "zipstream==1.1.4",
     "pytidylib==0.3.2",
     "argon2-cffi == 23.1.0",
-    "tzlocal == 5.3.1"
+    "tzlocal == 5.3.1",
+    "pydantic == 2.13.4",
 ]
 
 


### PR DESCRIPTION
This PR tackles bad course configurations by using Pydantic as a validation model. That way, instead of a generic "Unreachable Course", the user can see why exactly the course is not properly configured. The error show what course has a faulty config, said config element and why. 

This Pydantic validation model : 
- Checks for the fields' types
- Provides default values
- Forces lti parameters (previously in the Course object)
- Checks for a correct task dispenser
- Checks for correct `accessible` and `registration` parameters and their transformation into `AccessibleTime` objects

Fixes #1104