### PR TITLE
Fixing config access typo in APISubmissions

### DIFF
--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -200,8 +200,8 @@ class APISubmissions(APIAuthenticatedPage):
 
         user_input = task.adapt_input_for_backend(user_input)
 
-        if not task.input_is_consistent(user_input, current_app.config('ALLOWED_FILE_EXTENSIONS'),
-                                        current_app.config.get('MAX_FILE_SIZE')):
+        if not task.input_is_consistent(user_input, current_app.config['ALLOWED_FILE_EXTENSIONS'],
+                                        current_app.config['MAX_FILE_SIZE']):
             raise APIInvalidArguments()
 
         # Get debug info if the current user is an admin


### PR DESCRIPTION
Typo in config access. Switched from the use of `get()` to subscripting using `[ ]` to more easily catch errors.. In case of an error, subscripting raises an error directly. On the other hand, `.get()` would return a None potentially moving the bug elsewhere or make it more difficult to find.