### PR TITLE
Changing method signatures to pass username instead of using the session

### DIFF
--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -37,7 +37,7 @@ def _get_submissions(submission_manager, user_manager, courseid, taskid, with_in
         submissions = submission_manager.get_user_submissions(course, task, username)
     else:
         try:
-            submissions = [submission_manager.get_submission(submissionid)]
+            submissions = [submission_manager.get_submission(submissionid, username)]
         except:
             raise APINotFound("Submission not found")
         if submissions[0]["taskid"] != task.get_id() or submissions[0]["courseid"] != course.get_id():

--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -18,6 +18,8 @@ def _get_submissions(submission_manager, user_manager, courseid, taskid, with_in
         Helper for the GET methods of the two following classes
     """
 
+    username = session.username
+
     try:
         course = Course.get(courseid)
     except:
@@ -32,7 +34,7 @@ def _get_submissions(submission_manager, user_manager, courseid, taskid, with_in
         raise APINotFound("Task not found")
 
     if submissionid is None:
-        submissions = submission_manager.get_user_submissions(course, task)
+        submissions = submission_manager.get_user_submissions(course, task, username)
     else:
         try:
             submissions = [submission_manager.get_submission(submissionid)]

--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -212,7 +212,7 @@ class APISubmissions(APIAuthenticatedPage):
 
         # Start the submission
         try:
-            submissionid, _ = self.submission_manager.add_job(course, task, user_input, course.get_task_dispenser(), debug)
+            submissionid, _ = self.submission_manager.add_job(course, task, user_input, course.get_task_dispenser(), username, debug)
             return 200, {"submissionid": str(submissionid)}
         except Exception as ex:
             raise APIError(500, str(ex))

--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -25,7 +25,7 @@ def _get_submissions(submission_manager, user_manager, courseid, taskid, with_in
     except:
         raise APINotFound("Course not found")
 
-    if not user_manager.course_is_open_to_user(course, lti=False):
+    if not user_manager.course_is_open_to_user(course, username, lti=False):
         raise APIForbidden("You are not registered to this course")
 
     try:

--- a/inginious/frontend/pages/api/tasks.py
+++ b/inginious/frontend/pages/api/tasks.py
@@ -67,7 +67,7 @@ class APITasks(APIAuthenticatedPage):
         except:
             raise APINotFound("Course not found")
 
-        if not self.user_manager.course_is_open_to_user(course, lti=False):
+        if not self.user_manager.course_is_open_to_user(course, session.username, lti=False):
             raise APIForbidden("You are not registered to this course")
 
         if taskid is None:

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -15,7 +15,7 @@ from inginious.frontend.models import UserTask
 
 def handle_course_unavailable(user_manager, course):
     """ Displays the course_unavailable page or the course registration page """
-    reason = user_manager.course_is_open_to_user(course, lti=False, return_reason=True)
+    reason = user_manager.course_is_open_to_user(course, session.username, lti=False, return_reason=True)
     if reason == "unregistered_not_previewable":
         user_info = user_manager.get_user_info(session.username)
         if course.is_registration_possible(user_info):
@@ -58,7 +58,7 @@ class CoursePage(INGIniousAuthPage):
     def show_page(self, course):
         """ Prepares and shows the course page """
         username = session.username
-        if not self.user_manager.course_is_open_to_user(course, lti=False):
+        if not self.user_manager.course_is_open_to_user(course, username, lti=False):
             return handle_course_unavailable(self.user_manager, course)
         else:
             tasks = course.get_tasks()

--- a/inginious/frontend/pages/course_admin/submission.py
+++ b/inginious/frontend/pages/course_admin/submission.py
@@ -18,7 +18,7 @@ class SubmissionPage(INGIniousAdminPage):
 
     def fetch_submission(self, submissionid):
         try:
-            submission = self.submission_manager.get_submission(submissionid, False)
+            submission = self.submission_manager.get_submission(submissionid, session.username, user_check=False)
             if not submission:
                 raise NotFound(description=_("This submission doesn't exist."))
         except InvalidId as ex:

--- a/inginious/frontend/pages/group.py
+++ b/inginious/frontend/pages/group.py
@@ -30,7 +30,7 @@ class GroupPage(INGIniousAuthPage):
         data = request.args
         if self.user_manager.has_staff_rights_on_course(course):
             raise Forbidden(description=_("You can't access this page as a member of the staff."))
-        elif not (self.user_manager.course_is_open_to_user(course, lti=False)
+        elif not (self.user_manager.course_is_open_to_user(course, username, lti=False)
                   and self.user_manager.course_is_user_registered(course, username)):
             return render_template("course_unavailable.html")
         elif "register_group" in data:

--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -217,7 +217,7 @@ class BaseTaskPage(object):
 
             # Start the submission
             try:
-                submissionid, oldsubids = self.submission_manager.add_job(course, task, task_input, course.get_task_dispenser(), debug)
+                submissionid, oldsubids = self.submission_manager.add_job(course, task, task_input, course.get_task_dispenser(), username, debug)
                 return Response(content_type='application/json', response=json.dumps({
                     "status": "ok", "submissionid": str(submissionid), "remove": oldsubids,
                     "text": _("<b>Your submission has been sent...</b>")

--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -129,7 +129,7 @@ class BaseTaskPage(object):
                     students = group["students"]
                 # we don't care for the other case, as the student won't be able to submit.
 
-            submissions = self.submission_manager.get_user_submissions(course, task) if session.loggedin else []
+            submissions = self.submission_manager.get_user_submissions(course, task, session.username) if session.loggedin else []
             user_info = self.user_manager.get_user_info(username)
 
             # Visible tags

--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -84,7 +84,7 @@ class BaseTaskPage(object):
         userinput = flask.request.args
         if "submissionid" in userinput and "questionid" in userinput:
             # Download a previously submitted file
-            submission = self.submission_manager.get_submission(userinput["submissionid"], user_check=not is_staff)
+            submission = self.submission_manager.get_submission(userinput["submissionid"], username, user_check=not is_staff)
             if submission is None:
                 raise self.cp.app.notfound(message=_("Submission doesn't exist."))
             sinput = self.submission_manager.get_input_from_submission(submission, True)
@@ -228,12 +228,12 @@ class BaseTaskPage(object):
                 }))
 
         elif "@action" in userinput and userinput["@action"] == "check" and "submissionid" in userinput:
-            result = self.submission_manager.get_submission(userinput['submissionid'], user_check=not is_staff)
+            result = self.submission_manager.get_submission(userinput['submissionid'], username, user_check=not is_staff)
             if result is None:
                 return Response(content_type='application/json', response=json.dumps({
                     'status': "error",  "title": _("Error"), "text": _("Internal error")
                 }))
-            elif self.submission_manager.is_done(result.id, user_check=not is_staff):
+            elif self.submission_manager.is_done(result.id, username, user_check=not is_staff):
                 result = self.submission_manager.get_feedback_from_submission(result, show_everything=is_staff)
 
                 # user_task always exists as we called user_saw_task before
@@ -255,7 +255,7 @@ class BaseTaskPage(object):
                 ))
 
         elif "@action" in userinput and userinput["@action"] == "load_submission_input" and "submissionid" in userinput:
-            submission = self.submission_manager.get_submission(userinput["submissionid"], user_check=not is_staff)
+            submission = self.submission_manager.get_submission(userinput["submissionid"], username, user_check=not is_staff)
             submission = self.submission_manager.get_feedback_from_submission(submission, show_everything=is_staff)
             if not submission:
                 raise NotFound(description=_("Submission doesn't exist."))
@@ -265,7 +265,7 @@ class BaseTaskPage(object):
             ))
 
         elif "@action" in userinput and userinput["@action"] == "kill" and "submissionid" in userinput:
-            self.submission_manager.kill_running_submission(userinput["submissionid"])  # ignore return value
+            self.submission_manager.kill_running_submission(userinput["submissionid"], username)  # ignore return value
             return Response(content_type='application/json', response=json.dumps({'status': 'done'}))
         else:
             raise NotFound()

--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -399,7 +399,7 @@ class TaskPageStaticDownload(INGIniousPage):
         """ GET request """
         try:
             course = Course.get(courseid)
-            if not self.user_manager.course_is_open_to_user(course):
+            if not self.user_manager.course_is_open_to_user(course, session.username):
                 return handle_course_unavailable(self.user_manager, course)
 
             path_norm = posixpath.normpath(urllib.parse.unquote(path))

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -43,10 +43,10 @@ class WebAppSubmissionManager:
         )
 
     def _job_done_callback(self, submissionid, course, task, result, grade, problems, tests, custom, state, archive, stdout,
-                           stderr, task_dispenser,  newsub=True):
+                           stderr, task_dispenser, username, newsub=True):
         """ Callback called by Client when a job is done. Updates the submission in the database with the data returned after the completion of the
         job """
-        submission = self.get_submission(submissionid, False)
+        submission = self.get_submission(submissionid, username, user_check=False)
 
         if archive:
             submission.archive.put(archive)
@@ -91,7 +91,7 @@ class WebAppSubmissionManager:
             if lti_score_publisher:
                 lti_score_publisher.add(submission)
 
-    def _before_submission_insertion(self, course, task, inputdata, debug, obj):
+    def _before_submission_insertion(self, course, task, inputdata, debug, obj, username):
         """
         Called before any new submission is inserted into the database. Allows you to modify obj, the new document that will be inserted into the
         database. Should be overridden in subclasses.
@@ -190,7 +190,7 @@ class WebAppSubmissionManager:
         jobid = self._client.new_job(1, job_info, inputdata,
                                      (lambda result, grade, problems, tests, custom, state, archive, stdout, stderr:
                                       self._job_done_callback(submissionid, course, task, result, grade, problems, tests,
-                                                              custom, state, archive, stdout, stderr, task_dispenser, copy)),
+                                                              custom, state, archive, stdout, stderr, task_dispenser, username, copy)),
                                      "Frontend - {}".format(submission["username"]), debug, ssh_callback)
 
         # Callback may have been received, perform atomic operation
@@ -208,10 +208,10 @@ class WebAppSubmissionManager:
         """:return a list of available environments """
         return self._client.get_available_environments()
 
-    def get_submission(self, submissionid, user_check=True):
+    def get_submission(self, submissionid, username=None, user_check=True):
         """ Get a submission from the database """
         sub = Submission.objects.get(id=submissionid)
-        if user_check and not self.user_is_submission_owner(sub):
+        if user_check and not self.user_is_submission_owner(sub, username):
             return None
         return sub
 
@@ -287,7 +287,7 @@ class WebAppSubmissionManager:
         jobid = self._client.new_job(0, job_info, inputdata,
                                      (lambda result, grade, problems, tests, custom, state, archive, stdout, stderr:
                                       self._job_done_callback(submissionid, course, task, result, grade, problems, tests,
-                                                              custom, state, archive, stdout, stderr, task_dispenser, True)),
+                                                              custom, state, archive, stdout, stderr, task_dispenser, username, True)),
                                      "Frontend - {}".format(username), debug, ssh_callback)
 
         # Submission may already have been modified by callback,
@@ -378,29 +378,29 @@ class WebAppSubmissionManager:
                     )
         return submission
 
-    def is_running(self, submissionid, user_check=True):
+    def is_running(self, submissionid, username, user_check=True):
         """ Tells if a submission is running/in queue """
-        submission = self.get_submission(submissionid, user_check)
+        submission = self.get_submission(submissionid, username, user_check)
         return submission["status"] == "waiting"
 
-    def is_done(self, submissionid_or_submission, user_check=True):
+    def is_done(self, submissionid_or_submission, username, user_check=True):
         """ Tells if a submission is done and its result is available """
         # TODO: not a very nice way to avoid too many database call. Should be refactored.
         if isinstance(submissionid_or_submission, dict):
             submission = submissionid_or_submission
         else:
-            submission = self.get_submission(submissionid_or_submission, False)
-        if user_check and not self.user_is_submission_owner(submission):
+            submission = self.get_submission(submissionid_or_submission, username, user_check=False)
+        if user_check and not self.user_is_submission_owner(submission, username):
             return None
         return submission["status"] == "done" or submission["status"] == "error"
 
-    def kill_running_submission(self, submissionid, user_check=True):
+    def kill_running_submission(self, submissionid, username, user_check=True):
         """ Attempt to kill the remote job associated with this submission id.
         :param submissionid:
         :param user_check: Check if the current user owns this submission
         :return: True if the message asking to kill the job was sent, False if an error occurred
         """
-        submission = self.get_submission(submissionid, user_check)
+        submission = self.get_submission(submissionid, username, user_check)
         if not submission:
             self._logger.warning("Was asked to kill submission with id %s, but it cannot be found in the database", str(submissionid))
             return False
@@ -411,12 +411,12 @@ class WebAppSubmissionManager:
         self._client.kill_job(submission["jobid"])
         return True
 
-    def user_is_submission_owner(self, submission):
+    def user_is_submission_owner(self, submission, username):
         """ Returns true if the current user is the owner of this jobid, false else """
-        if not session.loggedin:
-            raise Exception("A user must be logged in to verify if he owns a jobid")
+        if username is None:
+            raise Exception("A user must be provided when checking for submission ownership")
 
-        return session.username in submission["username"]
+        return username in submission["username"]
 
     def get_user_submissions(self, course, task, username):
         """ Get all the user's submissions for a given task """

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -418,13 +418,10 @@ class WebAppSubmissionManager:
 
         return session.username in submission["username"]
 
-    def get_user_submissions(self, course, task):
+    def get_user_submissions(self, course, task, username):
         """ Get all the user's submissions for a given task """
-        if not session.loggedin:
-            raise Exception("A user must be logged in to get his submissions")
-
         cursor = Submission.objects(
-            username=session.username, taskid=task.get_id(), courseid=course.get_id()
+            username=username, taskid=task.get_id(), courseid=course.get_id()
         ).order_by("-submitted_on")
 
         return list(cursor)

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -101,7 +101,6 @@ class WebAppSubmissionManager:
         :param debug: True, False or "ssh". See add_job.
         :param obj: the new document that will be inserted
         """
-        username = session.username
         is_group_task =course.get_task_dispenser().get_group_submission(task.get_id())
 
         if is_group_task and not self._user_manager.has_staff_rights_on_course(course, username):
@@ -119,14 +118,13 @@ class WebAppSubmissionManager:
 
         # If we are submitting for a group, send the group (user list joined with ",") as username
         if "group" not in [p.get_id() for p in task.get_problems()]:  # do not overwrite
-            username = session.username
             if is_group_task and not self._user_manager.has_staff_rights_on_course(course, username):
                 group = Group.objects.get(courseid=course.id, students=username)
                 users = User.objects(username__in=group["students"])
                 inputdata["@username"] = ','.join(group["students"])
                 inputdata["@email"] = ','.join([user["email"] for user in users])
 
-    def _after_submission_insertion(self, course, task, inputdata, debug, submission, submissionid, task_dispenser):
+    def _after_submission_insertion(self, course, task, inputdata, debug, submission, submissionid, task_dispenser, username):
         """
                 Called after any new submission is inserted into the database, but before starting the job.  Should be overridden in subclasses.
                 :param task: Task related to the submission
@@ -136,7 +134,7 @@ class WebAppSubmissionManager:
                 :param submissionid: submission id of the submission
                 """
 
-        return self._delete_exceeding_submissions(session.username, course, task, task_dispenser)
+        return self._delete_exceeding_submissions(username, course, task, task_dispenser)
 
     def replay_job(self, course, task, submission, task_dispenser, copy=False, debug=False):
         """
@@ -215,7 +213,7 @@ class WebAppSubmissionManager:
             return None
         return sub
 
-    def add_job(self, course, task, inputdata, task_dispenser, debug=False):
+    def add_job(self, course, task, inputdata, task_dispenser, username, debug=False):
         """
         Add a job in the queue and returns a submission id.
         :param task:  Task instance
@@ -226,15 +224,12 @@ class WebAppSubmissionManager:
         :type debug: bool or string
         :returns: the new submission id and the removed submission id
         """
-        if not session.loggedin:
-            raise Exception("A user must be logged in to submit an object")
-
-        username = session.username
 
         # Prevent student from submitting several submissions together
         waiting_submission = Submission.objects(
             courseid=course.get_id(), taskid=task.get_id(), username=username, status="waiting"
         ).first()
+        user = User.objects.get(username=username)
 
         if waiting_submission:
             raise Exception("A submission is already pending for this task!")
@@ -251,8 +246,8 @@ class WebAppSubmissionManager:
         # Send additional data to the client in inputdata. For now, the username and the language. New fields can be added with the
         # new_submission hook
         inputdata["@username"] = username
-        inputdata["@email"] = session.email
-        inputdata["@lang"] = session.language
+        inputdata["@email"] = user.email
+        inputdata["@lang"] = user.language
         inputdata["@time"] = str(obj["submitted_on"])
 
         my_user_task = UserTask.objects.get(courseid=course.get_id(), taskid=task.get_id(), username=username)
@@ -262,7 +257,7 @@ class WebAppSubmissionManager:
 
         # Send LTI information to the client except "consumer_key"
         # to_dict() to avoid sending mongoengine BaseLists to ZMQ
-        if session.is_lti:
+        if session.is_lti: # TODO ; check correct behavior when no session
             lti_info = session.lti.to_mongo().to_dict()
             for key in lti_info:
                 if key == "consumer_key" or key.startswith("outcome"): # Skip "consumer_key" and "outcome*"
@@ -274,12 +269,12 @@ class WebAppSubmissionManager:
 
         plugin_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)
 
-        self._before_submission_insertion(course, task, inputdata, debug, obj)
+        self._before_submission_insertion(course, task, inputdata, debug, obj, username)
 
         submission = Submission(**obj)
         submission.set_input(inputdata)
         submissionid = submission.save().id
-        to_remove = self._after_submission_insertion(course, task, inputdata, debug, obj, submissionid, task_dispenser)
+        to_remove = self._after_submission_insertion(course, task, inputdata, debug, obj, submissionid, task_dispenser, username)
 
         ssh_callback = lambda host, port, user, password: self._handle_ssh_callback(submissionid, host, port, user, password)
         job_info = {"course": course, "task": task, "environment_type": task.get_environment_type(), "environment": task.get_environment_id()}
@@ -293,8 +288,8 @@ class WebAppSubmissionManager:
         # Submission may already have been modified by callback,
         Submission.objects(id=submissionid).update(jobid=jobid)
 
-        self._logger.info("New submission from %s - %s - %s/%s - %s", session.username,
-                          session.email, course.get_id(), task.get_id(), flask.request.remote_addr)
+        self._logger.info("New submission from %s - %s - %s/%s - %s", username,
+                          user.email, course.get_id(), task.get_id(), flask.request.remote_addr)
 
         return submissionid, to_remove
 

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -206,7 +206,7 @@ class WebAppSubmissionManager:
         """:return a list of available environments """
         return self._client.get_available_environments()
 
-    def get_submission(self, submissionid, username=None, user_check=True):
+    def get_submission(self, submissionid, username, user_check=True):
         """ Get a submission from the database """
         sub = Submission.objects.get(id=submissionid)
         if user_check and not self.user_is_submission_owner(sub, username):
@@ -257,7 +257,7 @@ class WebAppSubmissionManager:
 
         # Send LTI information to the client except "consumer_key"
         # to_dict() to avoid sending mongoengine BaseLists to ZMQ
-        if session.is_lti: # TODO ; check correct behavior when no session
+        if session.is_lti:
             lti_info = session.lti.to_mongo().to_dict()
             for key in lti_info:
                 if key == "consumer_key" or key.startswith("outcome"): # Skip "consumer_key" and "outcome*"
@@ -292,7 +292,6 @@ class WebAppSubmissionManager:
                           user.email, course.get_id(), task.get_id(), flask.request.remote_addr)
 
         return submissionid, to_remove
-
 
     def _delete_exceeding_submissions(self, username, course, task, task_dispenser):
         """ Deletes exceeding submissions from the database, to keep the database relatively small """
@@ -408,9 +407,6 @@ class WebAppSubmissionManager:
 
     def user_is_submission_owner(self, submission, username):
         """ Returns true if the current user is the owner of this jobid, false else """
-        if username is None:
-            raise Exception("A user must be provided when checking for submission ownership")
-
         return username in submission["username"]
 
     def get_user_submissions(self, course, task, username):

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -698,7 +698,7 @@ class UserManager:
 
         self._logger.info("User %s unregistered from course %s", username, course_id)
 
-    def course_is_open_to_user(self, course, username=None, lti=None, return_reason=False):
+    def course_is_open_to_user(self, course, username, lti=None, return_reason=False):
         """ Checks if a user is can access a course
 
         :param course: a Course object
@@ -721,8 +721,6 @@ class UserManager:
 
         :return: True if the user can access the course, False (or the reason if return_reason is True) otherwise
         """
-        if username is None:
-            username = session.username
         if lti == "auto":
             lti = session.is_lti
 


### PR DESCRIPTION
This PR is leading another one that introduces the use of tokens to authenticate for api calls.
It changes multiple method signatures to pass the username  instead of relying on the session, which will be unavailable with the use of the tokens. 

I tried to avoid the use of default None values for the username. Unfortunately, this sometimes produces strange method signatures in my opinion. Do you think it is correct